### PR TITLE
build.sh: fix copying proto directory

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -28,4 +28,4 @@ cp package.json build/
 cp README.md build/
 
 # Copy Proto Files
-cp -R ./src/proto/ ./build
+cp -R ./src/proto ./build


### PR DESCRIPTION
# Description

In mac, the extra slash copies the contents of proto folder into build.
See this commit for detailed explanation - https://github.com/dapr/js-sdk/issues/129#issuecomment-958793506

## Issue reference

https://github.com/dapr/js-sdk/issues/129

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
