### PR TITLE
fix: wrong references in imports

### DIFF
--- a/src/types/Request.type.ts
+++ b/src/types/Request.type.ts
@@ -1,6 +1,6 @@
 import { IEtag } from "./Etag.type";
 import { IRequestMetadata } from "./RequestMetadata.type";
-import { IStateOptions } from "./StateOptions.type";
+import { IStateOptions } from "./state/StateOptions.type";
 
 export type IRequest = {
   key: string;

--- a/src/types/state/StateOptions.type.ts
+++ b/src/types/state/StateOptions.type.ts
@@ -1,5 +1,5 @@
-import { EStateConsistency } from "../enum/StateConsistency.enum";
-import { EStateConcurrency } from "../enum/StateConcurrency.enum";
+import { EStateConsistency } from "../../enum/StateConsistency.enum";
+import { EStateConcurrency } from "../../enum/StateConcurrency.enum";
 
 export type IStateOptions = {
   concurrency: EStateConcurrency;


### PR DESCRIPTION
# Description

The wrong references in the imports as described in issue #175 have been adjusted to match the structure

## Issue reference

See #175 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests -> not relevant
* [ ] Extended the documentation -> not relevant
