### PR TITLE
Fix for build script

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Stop on first errror in execustion 
+set -e
+
 echo "====================================================="
 echo "==================== Dapr JS SDK ===================="
 echo "====================================================="
@@ -20,7 +24,7 @@ mkdir build/
 echo "Building Library"
 npm install > /dev/null
 npm run lint > /dev/null
-tsc --outDir ./build/ > /dev/null
+tsc --outDir ./build/
 
 # Prepare Publish
 echo "Preparing Publish"


### PR DESCRIPTION
Signed-off-by: Christian Lechner <lechnerc77@users.noreply.github.com>

# Description

Changed the `build.sh` script as proposed in issue  #177 (original issue #175): 

* added `set -e` to abort after first error
* removed forward of `tsc` output to `\dev\null`

## Issue reference

#177

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
