### PR TITLE
Use environment variables to initialize client and server

### DIFF
--- a/src/implementation/Client/DaprClient.ts
+++ b/src/implementation/Client/DaprClient.ts
@@ -53,14 +53,14 @@ export default class DaprClient {
   readonly actor: IClientActorBuilder;
 
   constructor(
-    daprHost = Settings.getDefaultHost()
+    daprHost?: string
     , daprPort?: string
     , communicationProtocol: CommunicationProtocolEnum = CommunicationProtocolEnum.HTTP
     , options: DaprClientOptions = {
       isKeepAlive: true
     }
   ) {
-    this.daprHost = daprHost;
+    this.daprHost = daprHost ?? Settings.getDefaultHost();
     this.daprPort = daprPort ?? Settings.getDefaultPort(communicationProtocol);
     this.communicationProtocol = communicationProtocol;
     this.options = options;

--- a/src/implementation/Client/DaprClient.ts
+++ b/src/implementation/Client/DaprClient.ts
@@ -53,14 +53,14 @@ export default class DaprClient {
   readonly actor: IClientActorBuilder;
 
   constructor(
-    daprHost?: string
+    daprHost = Settings.getDefaultHost()
     , daprPort?: string
     , communicationProtocol: CommunicationProtocolEnum = CommunicationProtocolEnum.HTTP
     , options: DaprClientOptions = {
       isKeepAlive: true
     }
   ) {
-    this.daprHost = daprHost ?? Settings.getDefaultHost();
+    this.daprHost = daprHost;
     this.daprPort = daprPort ?? Settings.getDefaultPort(communicationProtocol);
     this.communicationProtocol = communicationProtocol;
     this.options = options;

--- a/src/implementation/Client/DaprClient.ts
+++ b/src/implementation/Client/DaprClient.ts
@@ -33,6 +33,7 @@ import HTTPClient from './HTTPClient/HTTPClient';
 
 import CommunicationProtocolEnum from '../../enum/CommunicationProtocol.enum';
 import { DaprClientOptions } from '../../types/DaprClientOptions';
+import { Settings } from '../../utils/Settings.util';
 
 export default class DaprClient {
   readonly daprHost: string;
@@ -52,15 +53,15 @@ export default class DaprClient {
   readonly actor: IClientActorBuilder;
 
   constructor(
-    daprHost: string
-    , daprPort: string
+    daprHost?: string
+    , daprPort?: string
     , communicationProtocol: CommunicationProtocolEnum = CommunicationProtocolEnum.HTTP
     , options: DaprClientOptions = {
       isKeepAlive: true
     }
   ) {
-    this.daprHost = daprHost;
-    this.daprPort = daprPort;
+    this.daprHost = daprHost ?? Settings.getDefaultHost();
+    this.daprPort = daprPort ?? Settings.getDefaultPort(communicationProtocol);
     this.communicationProtocol = communicationProtocol;
     this.options = options;
 

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -4,21 +4,20 @@ import { DaprClient } from "../../../proto/dapr/proto/runtime/v1/dapr_grpc_pb"
 import IClient from "../../../interfaces/Client/IClient";
 import CommunicationProtocolEnum from "../../../enum/CommunicationProtocol.enum";
 import { DaprClientOptions } from "../../../types/DaprClientOptions";
+import { Settings } from '../../../utils/Settings.util';
 
 export default class GRPCClient implements IClient {
-  private isInitialized: boolean;
   private readonly client: DaprClient;
   private readonly clientCredentials: grpc.ChannelCredentials;
   private readonly clientHost: string;
   private readonly clientPort: string;
   private readonly options: DaprClientOptions;
 
-  constructor(host = "127.0.0.1", port = "50050", options: DaprClientOptions = {
+  constructor(host?: string, port?: string, options: DaprClientOptions = {
     isKeepAlive: true
   }) {
-    this.isInitialized = true;
-    this.clientHost = host;
-    this.clientPort = port;
+    this.clientHost = host ?? Settings.getDefaultHost();
+    this.clientPort = port ?? Settings.getDefaultGrpcPort();
     this.clientCredentials = ChannelCredentials.createInsecure();
     this.options = options;
 

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -13,9 +13,13 @@ export default class GRPCClient implements IClient {
   private readonly clientPort: string;
   private readonly options: DaprClientOptions;
 
-  constructor(host?: string, port?: string, options: DaprClientOptions = {
-    isKeepAlive: true
-  }) {
+  constructor(
+    host = Settings.getDefaultHost()
+    , port = Settings.getDefaultGrpcPort()
+    , options: DaprClientOptions = {
+      isKeepAlive: true
+    }
+  ) {
     this.clientHost = host ?? Settings.getDefaultHost();
     this.clientPort = port ?? Settings.getDefaultGrpcPort();
     this.clientCredentials = ChannelCredentials.createInsecure();

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -20,8 +20,8 @@ export default class GRPCClient implements IClient {
       isKeepAlive: true
     }
   ) {
-    this.clientHost = host ?? Settings.getDefaultHost();
-    this.clientPort = port ?? Settings.getDefaultGrpcPort();
+    this.clientHost = host;
+    this.clientPort = port;
     this.clientCredentials = ChannelCredentials.createInsecure();
     this.options = options;
 

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -4,9 +4,9 @@ import IClient from "../../../interfaces/Client/IClient";
 import http from "http";
 import https from "https";
 import { DaprClientOptions } from "../../../types/DaprClientOptions";
+import { Settings } from '../../../utils/Settings.util';
 
 export default class HTTPClient implements IClient {
-  private readonly isInitialized: boolean;
   private client: typeof fetch;
   private readonly clientHost: string;
   private readonly clientPort: string;
@@ -16,12 +16,11 @@ export default class HTTPClient implements IClient {
   private readonly httpAgent;
   private readonly httpsAgent;
 
-  constructor(host = "127.0.0.1", port = "50050", options: DaprClientOptions = {
+  constructor(host?: string, port?: string, options: DaprClientOptions = {
     isKeepAlive: true
   }) {
-    this.isInitialized = true;
-    this.clientHost = host;
-    this.clientPort = port;
+    this.clientHost = host ?? Settings.getDefaultHost();
+    this.clientPort = port ?? Settings.getDefaultHttpPort();
     this.options = options;
 
     if (!this.clientHost.startsWith('http://') && !this.clientHost.startsWith('https://')) {

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -16,11 +16,15 @@ export default class HTTPClient implements IClient {
   private readonly httpAgent;
   private readonly httpsAgent;
 
-  constructor(host?: string, port?: string, options: DaprClientOptions = {
-    isKeepAlive: true
-  }) {
-    this.clientHost = host ?? Settings.getDefaultHost();
-    this.clientPort = port ?? Settings.getDefaultHttpPort();
+  constructor(
+    host = Settings.getDefaultHost()
+    , port = Settings.getDefaultHttpPort()
+    , options: DaprClientOptions = {
+      isKeepAlive: true
+    }
+  ) {
+    this.clientHost = host;
+    this.clientPort = port ?? port;
     this.options = options;
 
     if (!this.clientHost.startsWith('http://') && !this.clientHost.startsWith('https://')) {

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -24,7 +24,7 @@ export default class HTTPClient implements IClient {
     }
   ) {
     this.clientHost = host;
-    this.clientPort = port ?? port;
+    this.clientPort = port;
     this.options = options;
 
     if (!this.clientHost.startsWith('http://') && !this.clientHost.startsWith('https://')) {

--- a/src/implementation/Server/DaprServer.ts
+++ b/src/implementation/Server/DaprServer.ts
@@ -36,18 +36,18 @@ export default class DaprServer {
   readonly client: DaprClient;
 
   constructor(
-    serverHost = Settings.getDefaultHost()
+    serverHost?: string
     , serverPort?: string
-    , daprHost = Settings.getDefaultHost()
+    , daprHost?: string
     , daprPort?: string
     , communicationProtocol: CommunicationProtocolEnum = CommunicationProtocolEnum.HTTP
     , clientOptions: DaprClientOptions = {
       isKeepAlive: true
     }
   ) {
-    this.serverHost = serverHost;
+    this.serverHost = serverHost ?? Settings.getDefaultHost();
     this.serverPort = serverPort ?? Settings.getDefaultAppPort(communicationProtocol);
-    this.daprHost = daprHost;
+    this.daprHost = daprHost ?? Settings.getDefaultHost();
     this.daprPort = daprPort ?? Settings.getDefaultPort(communicationProtocol);
 
     // Create a client to interface with the sidecar from the server side

--- a/src/implementation/Server/DaprServer.ts
+++ b/src/implementation/Server/DaprServer.ts
@@ -18,6 +18,7 @@ import HTTPServerInvoker from './HTTPServer/invoker';
 import HTTPServerActor from './HTTPServer/actor';
 import { DaprClientOptions } from '../../types/DaprClientOptions';
 import { DaprClient } from '../..';
+import { Settings } from '../../utils/Settings.util';
 
 export default class DaprServer {
   // App details
@@ -35,19 +36,19 @@ export default class DaprServer {
   readonly client: DaprClient;
 
   constructor(
-    serverHost = "127.0.0.1"
-    , serverPort: string = process.env.DAPR_SERVER_PORT || "50050"
-    , daprHost = "127.0.0.1"
-    , daprPort = "50051"
+    serverHost = Settings.getDefaultHost()
+    , serverPort?: string
+    , daprHost = Settings.getDefaultHost()
+    , daprPort?: string
     , communicationProtocol: CommunicationProtocolEnum = CommunicationProtocolEnum.HTTP
     , clientOptions: DaprClientOptions = {
       isKeepAlive: true
     }
   ) {
     this.serverHost = serverHost;
-    this.serverPort = serverPort;
+    this.serverPort = serverPort ?? Settings.getDefaultAppPort(communicationProtocol);
     this.daprHost = daprHost;
-    this.daprPort = daprPort;
+    this.daprPort = daprPort ?? Settings.getDefaultPort(communicationProtocol);
 
     // Create a client to interface with the sidecar from the server side
     this.client = new DaprClient(daprHost, daprPort, communicationProtocol, clientOptions);

--- a/src/utils/Settings.util.ts
+++ b/src/utils/Settings.util.ts
@@ -2,7 +2,9 @@ import CommunicationProtocolEnum from "../enum/CommunicationProtocol.enum";
 
 export class Settings {
     private static readonly defaultHost: string = "127.0.0.1";
+    private static readonly defaultHttpAppPort: string = "3000";
     private static readonly defaultHttpPort: string = "3500";
+    private static readonly defaultGrpcAppPort: string = "50000";
     private static readonly defaultGrpcPort: string = "50001";
 
     static getDefaultHost(): string {
@@ -17,12 +19,39 @@ export class Settings {
         return process.env.DAPR_GRPC_PORT ?? Settings.defaultGrpcPort;
     }
 
+    /**
+     * Gets the default port that the Dapr sidecar is listening to.
+     * @param communicationProtocolEnum communication protocol
+     * @returns port number
+     */
     static getDefaultPort(communicationProtocolEnum: CommunicationProtocolEnum): string {
         switch (communicationProtocolEnum) {
             case CommunicationProtocolEnum.GRPC:
                 return this.getDefaultGrpcPort();
             default:
                 return this.getDefaultHttpPort();
+        }
+    }
+
+    static getDefaultHttpAppPort(): string {
+        return process.env.APP_PORT ?? Settings.defaultHttpAppPort;
+    }
+
+    static getDefaultGrpcAppPort(): string {
+        return process.env.APP_PORT ?? Settings.defaultGrpcAppPort;
+    }
+
+    /**
+     * Gets the default port that the application is listening on.
+     * @param communicationProtocolEnum communication protocol
+     * @returns port number
+     */
+    static getDefaultAppPort(communicationProtocolEnum: CommunicationProtocolEnum): string {
+        switch (communicationProtocolEnum) {
+            case CommunicationProtocolEnum.GRPC:
+                return this.getDefaultGrpcAppPort();        
+            default:
+                return this.getDefaultHttpAppPort();
         }
     }
 }

--- a/src/utils/Settings.util.ts
+++ b/src/utils/Settings.util.ts
@@ -1,0 +1,28 @@
+import CommunicationProtocolEnum from "../enum/CommunicationProtocol.enum";
+
+export class Settings {
+    private static readonly defaultHost: string = "127.0.0.1";
+    private static readonly defaultHttpPort: string = "3500";
+    private static readonly defaultGrpcPort: string = "50001";
+
+    static getDefaultHost(): string {
+        return Settings.defaultHost;
+    }
+
+    static getDefaultHttpPort(): string {
+        return process.env.DAPR_HTTP_PORT ?? Settings.defaultHttpPort;
+    }
+
+    static getDefaultGrpcPort(): string {
+        return process.env.DAPR_GRPC_PORT ?? Settings.defaultGrpcPort;
+    }
+
+    static getDefaultPort(communicationProtocolEnum: CommunicationProtocolEnum): string {
+        switch (communicationProtocolEnum) {
+            case CommunicationProtocolEnum.GRPC:
+                return this.getDefaultGrpcPort();
+            default:
+                return this.getDefaultHttpPort();
+        }
+    }
+}

--- a/test/unit/utils/Settings.util.test.ts
+++ b/test/unit/utils/Settings.util.test.ts
@@ -1,0 +1,25 @@
+import { CommunicationProtocolEnum } from "../../../src";
+import { Settings } from "../../../src/utils/Settings.util";
+
+describe('Settings', () => {
+    describe('getDefaultPort returns the correct default when', () => {
+        it('communication protocol is GRPC', () => {
+            expect(Settings.getDefaultPort(CommunicationProtocolEnum.GRPC))
+                .toEqual(Settings.getDefaultGrpcPort())
+        });
+        it('communication protocol is HTTP', () => {
+            expect(Settings.getDefaultPort(CommunicationProtocolEnum.HTTP))
+                .toEqual(Settings.getDefaultHttpPort())
+        });
+    });
+    describe('getDefaultAppPort returns the correct default when', () => {
+        it('communication protocol is GRPC', () => {
+            expect(Settings.getDefaultAppPort(CommunicationProtocolEnum.GRPC))
+                .toEqual(Settings.getDefaultGrpcAppPort())
+        });
+        it('communication protocol is HTTP', () => {
+            expect(Settings.getDefaultAppPort(CommunicationProtocolEnum.HTTP))
+                .toEqual(Settings.getDefaultHttpAppPort())
+        });
+    });
+})


### PR DESCRIPTION
# Description

This PR makes `DaprClient` and `DaprServer` configurable using environment variables. If missing, they fallback to a sane default value. 

## Issue reference

Please reference the issue this PR will close: #178 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [x] Created/updated tests
* [ ] Extended the documentation
