### PR TITLE
Update Eslint configuration to enforce error for unused vars rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,7 @@
     "rules": {
         "@typescript-eslint/ban-ts-comment": "off",
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-unused-vars": ["warn", {
+        "@typescript-eslint/no-unused-vars": ["error", {
             "varsIgnorePattern": "^_",
             "argsIgnorePattern": "^_"
         }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "dapr-client",
-    "version": "2.0.1",
+    "version": "2.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "dapr-client",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "ISC",
             "dependencies": {
                 "@grpc/grpc-js": "^1.3.7",


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Per #195, we were looking to enforce eslint, but it already configures each rule as "error" by default. The only rule we were throwing warning for was "@typescript-eslint/no-unused-vars" and this PR changes that. Now, it errors out like this:
![image](https://user-images.githubusercontent.com/22132944/156002525-2ee0063e-6311-4ed7-87fe-1013b754c7ae.png)


## Issue reference

Please reference the issue this PR will close: #195 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* (NA) Created/updated tests
* (NA) Extended the documentation
