### PR TITLE
Revert "[Blocked] Fix e2e tests to match query API changes"

### DIFF
--- a/test/e2e/main.http.test.ts
+++ b/test/e2e/main.http.test.ts
@@ -340,15 +340,15 @@ describe('http/main', () => {
         filter: {
           OR: [
             {
-              EQ: { "person.org": "Dev Ops" }
+              EQ: { "value.person.org": "Dev Ops" }
             },
             {
               "AND": [
                 {
-                  "EQ": { "person.org": "Finance" }
+                  "EQ": { "value.person.org": "Finance" }
                 },
                 {
-                  "IN": { "state": ["CA", "WA"] }
+                  "IN": { "value.state": ["CA", "WA"] }
                 }
               ]
             }
@@ -356,7 +356,7 @@ describe('http/main', () => {
         },
         sort: [
           {
-            key: "state",
+            key: "value.state",
             order: "DESC"
           }
         ],
@@ -365,7 +365,6 @@ describe('http/main', () => {
         }
       });
 
-      expect(res.results).toBeDefined();
       expect(res.results.length).toEqual(4);
       expect(res.results.map(i => i.key).indexOf("key-1")).toBeGreaterThan(-1);
       expect(res.results.map(i => i.key).indexOf("key-4")).toBeGreaterThan(-1);


### PR DESCRIPTION
Reverts dapr/js-sdk#199 since the functionality is not available in dapr/dapr.
It will be merged once dapr/dapr v1.7 is released.