### PR TITLE
Fix Dapr bot: don't use ES syntax

### DIFF
--- a/.github/scripts/dapr_bot.js
+++ b/.github/scripts/dapr_bot.js
@@ -156,7 +156,7 @@ async function executeEndToEndTests(github, context, isPullRequest) {
 }
 
 
-export default async ({ github, context }) => {
+module.exports = async ({ github, context }) => {
     const payload = context.payload;
     const issue = context.issue;
     const isFromPulls = !!payload.issue.pull_request;


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

ES syntax was causing issues. It was a last-minute change while merging #210 (suggested by VS code).

## Issue reference

Please reference the issue this PR will close: #239 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
