### PR TITLE
fix(implementation): Check if data is Buffer already

### DIFF
--- a/src/implementation/Client/GRPCClient/binding.ts
+++ b/src/implementation/Client/GRPCClient/binding.ts
@@ -31,7 +31,7 @@ export default class GRPCClientBinding implements IClientBinding {
     const msgService = new InvokeBindingRequest();
     msgService.setName(bindingName);
     msgService.setOperation(operation);
-    msgService.setData(SerializerUtil.serializeGrpc(data).serialized);
+    msgService.setData(SerializerUtil.serializeGrpc(data).serializedData);
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/implementation/Client/GRPCClient/binding.ts
+++ b/src/implementation/Client/GRPCClient/binding.ts
@@ -31,7 +31,7 @@ export default class GRPCClientBinding implements IClientBinding {
     const msgService = new InvokeBindingRequest();
     msgService.setName(bindingName);
     msgService.setOperation(operation);
-    msgService.setData(SerializerUtil.serializeGrpc(data));
+    msgService.setData(SerializerUtil.serializeGrpc(data).serialized);
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/implementation/Client/GRPCClient/binding.ts
+++ b/src/implementation/Client/GRPCClient/binding.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import GRPCClient from './GRPCClient';
 import { InvokeBindingRequest, InvokeBindingResponse } from '../../../proto/dapr/proto/runtime/v1/dapr_pb';
 import IClientBinding from '../../../interfaces/Client/IClientBinding';
+import * as SerializerUtil from "../../../utils/Serializer.util";
 
 // https://docs.dapr.io/reference/api/bindings_api/
 export default class GRPCClientBinding implements IClientBinding {
@@ -30,7 +31,7 @@ export default class GRPCClientBinding implements IClientBinding {
     const msgService = new InvokeBindingRequest();
     msgService.setName(bindingName);
     msgService.setOperation(operation);
-    msgService.setData(Buffer.from(JSON.stringify(data), "utf-8"));
+    msgService.setData(SerializerUtil.serializeGrpc(data));
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -55,13 +55,14 @@ export default class GRPCClientInvoker implements IClientInvoker {
     httpExtension.setVerb(HttpVerbUtil.convertHttpVerbStringToNumber(method));
 
     const msgSerialized = new Any();
-    msgSerialized.setValue(SerializerUtil.serializeGrpc(data));
+    const {serialized, contentType} = SerializerUtil.serializeGrpc(data);
+    msgSerialized.setValue(serialized);
 
     const msgInvoke = new InvokeRequest();
     msgInvoke.setMethod(methodName);
     msgInvoke.setHttpExtension(httpExtension);
     msgInvoke.setData(msgSerialized);
-    msgInvoke.setContentType("application/json");
+    msgInvoke.setContentType(contentType);
 
     msgInvokeService.setMessage(msgInvoke);
 

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -55,8 +55,8 @@ export default class GRPCClientInvoker implements IClientInvoker {
     httpExtension.setVerb(HttpVerbUtil.convertHttpVerbStringToNumber(method));
 
     const msgSerialized = new Any();
-    const {serialized, contentType} = SerializerUtil.serializeGrpc(data);
-    msgSerialized.setValue(serialized);
+    const {serializedData, contentType} = SerializerUtil.serializeGrpc(data);
+    msgSerialized.setValue(serializedData);
 
     const msgInvoke = new InvokeRequest();
     msgInvoke.setMethod(methodName);

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -19,6 +19,7 @@ import { HTTPExtension, InvokeRequest, InvokeResponse } from '../../../proto/dap
 import { InvokeServiceRequest } from '../../../proto/dapr/proto/runtime/v1/dapr_pb';
 import * as HttpVerbUtil from "../../../utils/HttpVerb.util";
 import IClientInvoker from '../../../interfaces/Client/IClientInvoker';
+import * as SerializerUtil from "../../../utils/Serializer.util"
 
 // https://docs.dapr.io/reference/api/service_invocation_api/
 export default class GRPCClientInvoker implements IClientInvoker {
@@ -54,7 +55,7 @@ export default class GRPCClientInvoker implements IClientInvoker {
     httpExtension.setVerb(HttpVerbUtil.convertHttpVerbStringToNumber(method));
 
     const msgSerialized = new Any();
-    msgSerialized.setValue(Buffer.from(JSON.stringify(data), "utf-8"));
+    msgSerialized.setValue(SerializerUtil.serializeGrpc(data));
 
     const msgInvoke = new InvokeRequest();
     msgInvoke.setMethod(methodName);

--- a/src/implementation/Client/GRPCClient/pubsub.ts
+++ b/src/implementation/Client/GRPCClient/pubsub.ts
@@ -33,7 +33,7 @@ export default class GRPCClientPubSub implements IClientPubSub {
     const msgService = new PublishEventRequest();
     msgService.setPubsubName(pubSubName);
     msgService.setTopic(topic);
-    msgService.setData(SerializerUtil.serializeGrpc(data).serialized);
+    msgService.setData(SerializerUtil.serializeGrpc(data).serializedData);
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/implementation/Client/GRPCClient/pubsub.ts
+++ b/src/implementation/Client/GRPCClient/pubsub.ts
@@ -15,6 +15,7 @@ import GRPCClient from './GRPCClient';
 import { PublishEventRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import IClientPubSub from "../../../interfaces/Client/IClientPubSub";
 import { Logger } from '../../../logger/Logger';
+import * as SerializerUtil from "../../../utils/Serializer.util";
 
 // https://docs.dapr.io/reference/api/pubsub_api/
 export default class GRPCClientPubSub implements IClientPubSub {
@@ -32,7 +33,7 @@ export default class GRPCClientPubSub implements IClientPubSub {
     const msgService = new PublishEventRequest();
     msgService.setPubsubName(pubSubName);
     msgService.setTopic(topic);
-    msgService.setData(Buffer.from(JSON.stringify(data), "utf-8"));
+    msgService.setData(SerializerUtil.serializeGrpc(data));
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/implementation/Client/GRPCClient/pubsub.ts
+++ b/src/implementation/Client/GRPCClient/pubsub.ts
@@ -33,7 +33,7 @@ export default class GRPCClientPubSub implements IClientPubSub {
     const msgService = new PublishEventRequest();
     msgService.setPubsubName(pubSubName);
     msgService.setTopic(topic);
-    msgService.setData(SerializerUtil.serializeGrpc(data));
+    msgService.setData(SerializerUtil.serializeGrpc(data).serialized);
 
     return new Promise((resolve, reject) => {
       const client = this.client.getClient();

--- a/src/utils/Serializer.util.ts
+++ b/src/utils/Serializer.util.ts
@@ -11,14 +11,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export function serializeGrpc(data: any): Buffer {
+export function serializeGrpc(data: any): {serialized: Buffer, contentType: string} {
     let serialized = data;
-
+    let contentType = "application/json";
     if (data instanceof Buffer) {
         serialized = data;
+        contentType = "application/octet-stream";
     } else {
         serialized = Buffer.from(JSON.stringify(data), "utf-8");
+        contentType = "application/json";
     }
 
-    return serialized;
+    return {serialized, contentType};
 }

--- a/src/utils/Serializer.util.ts
+++ b/src/utils/Serializer.util.ts
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export function serializeGrpc(data: any) {
+    let serialized = data;
+
+    if (data instanceof Buffer) {
+        serialized = data;
+    } else {
+        serialized = Buffer.from(JSON.stringify(data), "utf-8");
+    }
+
+    return serialized;
+}

--- a/src/utils/Serializer.util.ts
+++ b/src/utils/Serializer.util.ts
@@ -11,16 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export function serializeGrpc(data: any): {serialized: Buffer, contentType: string} {
-    let serialized = data;
-    let contentType = "application/json";
-    if (data instanceof Buffer) {
-        serialized = data;
-        contentType = "application/octet-stream";
-    } else {
-        serialized = Buffer.from(JSON.stringify(data), "utf-8");
+export function serializeGrpc(data: any): {serializedData: Buffer, contentType: string} {
+    let serializedData = data;
+    let contentType = "application/octet-stream";
+    if (!(data instanceof Buffer)) {
+        serializedData = Buffer.from(JSON.stringify(data), "utf-8");
         contentType = "application/json";
     }
 
-    return {serialized, contentType};
+    return {serializedData, contentType};
 }

--- a/test/e2e/grpc/server.test.ts
+++ b/test/e2e/grpc/server.test.ts
@@ -62,11 +62,35 @@ describe('grpc/server', () => {
       // @ts-ignore
       expect(mockBindingReceive.mock.calls[0][0]['hello']).toEqual('world');
     });
+
+    it('should be able to send events with Buffer format and receive events ', async () => {
+      await server.client.binding.send('binding-mqtt', 'create', Buffer.from(JSON.stringify({ hello: 'world' })));
+
+      // Delay a bit for event to arrive
+      await new Promise((resolve, _reject) => setTimeout(resolve, 250));
+      expect(mockBindingReceive.mock.calls.length).toBe(1);
+
+      // Also test for receiving data
+      // @ts-ignore
+      expect(mockBindingReceive.mock.calls[0][0]['hello']).toEqual('world');
+    });
   });
 
   describe('pubsub', () => {
     it('should be able to send and receive events', async () => {
       await server.client.pubsub.publish('pubsub-redis', 'test-topic', { hello: 'world' });
+
+      // Delay a bit for event to arrive
+      await new Promise((resolve, _reject) => setTimeout(resolve, 250));
+      expect(mockPubSubSubscribe.mock.calls.length).toBe(1);
+
+      // Also test for receiving data
+      // @ts-ignore
+      expect(mockPubSubSubscribe.mock.calls[0][0]['hello']).toEqual('world');
+    });
+
+    it('should be able to send events with Buffer format and receive events', async () => {
+      await server.client.pubsub.publish('pubsub-redis', 'test-topic', Buffer.from(JSON.stringify({ hello: 'world' })));
 
       // Delay a bit for event to arrive
       await new Promise((resolve, _reject) => setTimeout(resolve, 250));

--- a/test/e2e/grpc/server.test.ts
+++ b/test/e2e/grpc/server.test.ts
@@ -62,35 +62,11 @@ describe('grpc/server', () => {
       // @ts-ignore
       expect(mockBindingReceive.mock.calls[0][0]['hello']).toEqual('world');
     });
-
-    it('should be able to send events with Buffer format and receive events ', async () => {
-      await server.client.binding.send('binding-mqtt', 'create', Buffer.from(JSON.stringify({ hello: 'world' })));
-
-      // Delay a bit for event to arrive
-      await new Promise((resolve, _reject) => setTimeout(resolve, 250));
-      expect(mockBindingReceive.mock.calls.length).toBe(1);
-
-      // Also test for receiving data
-      // @ts-ignore
-      expect(mockBindingReceive.mock.calls[0][0]['hello']).toEqual('world');
-    });
   });
 
   describe('pubsub', () => {
     it('should be able to send and receive events', async () => {
       await server.client.pubsub.publish('pubsub-redis', 'test-topic', { hello: 'world' });
-
-      // Delay a bit for event to arrive
-      await new Promise((resolve, _reject) => setTimeout(resolve, 250));
-      expect(mockPubSubSubscribe.mock.calls.length).toBe(1);
-
-      // Also test for receiving data
-      // @ts-ignore
-      expect(mockPubSubSubscribe.mock.calls[0][0]['hello']).toEqual('world');
-    });
-
-    it('should be able to send events with Buffer format and receive events', async () => {
-      await server.client.pubsub.publish('pubsub-redis', 'test-topic', Buffer.from(JSON.stringify({ hello: 'world' })));
 
       // Delay a bit for event to arrive
       await new Promise((resolve, _reject) => setTimeout(resolve, 250));

--- a/test/unit/utils/Serializer.util.test.ts
+++ b/test/unit/utils/Serializer.util.test.ts
@@ -11,14 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export function serializeGrpc(data: any): Buffer {
-    let serialized = data;
+import * as SerializerUtil from "../../../src/utils/Serializer.util"
 
-    if (data instanceof Buffer) {
-        serialized = data;
-    } else {
-        serialized = Buffer.from(JSON.stringify(data), "utf-8");
-    }
-
-    return serialized;
-}
+describe('serializer', () => {
+    it('Object should be serialized to Buffer', () => {
+        let data = SerializerUtil.serializeGrpc({ Hello: 'World' });
+        expect(Buffer.compare(data, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
+    });
+    it('Buffer object should not be serialized again', () => {
+        let data = SerializerUtil.serializeGrpc(Buffer.from('Hello World'));
+        expect(Buffer.compare(data, Buffer.from('Hello World'))).toEqual(0);
+    });
+});

--- a/test/unit/utils/Serializer.util.test.ts
+++ b/test/unit/utils/Serializer.util.test.ts
@@ -16,10 +16,12 @@ import * as SerializerUtil from "../../../src/utils/Serializer.util"
 describe('serializer', () => {
     it('Object should be serialized to Buffer', () => {
         const data = SerializerUtil.serializeGrpc({ Hello: 'World' });
-        expect(Buffer.compare(data, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
+        expect(Buffer.compare(data.serialized, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
+        expect(data.contentType).toEqual("application/json");
     });
     it('Buffer object should not be serialized again', () => {
         const data = SerializerUtil.serializeGrpc(Buffer.from('Hello World'));
-        expect(Buffer.compare(data, Buffer.from('Hello World'))).toEqual(0);
+        expect(Buffer.compare(data.serialized, Buffer.from('Hello World'))).toEqual(0);
+        expect(data.contentType).toEqual("application/octet-stream");
     });
 });

--- a/test/unit/utils/Serializer.util.test.ts
+++ b/test/unit/utils/Serializer.util.test.ts
@@ -15,11 +15,11 @@ import * as SerializerUtil from "../../../src/utils/Serializer.util"
 
 describe('serializer', () => {
     it('Object should be serialized to Buffer', () => {
-        let data = SerializerUtil.serializeGrpc({ Hello: 'World' });
+        const data = SerializerUtil.serializeGrpc({ Hello: 'World' });
         expect(Buffer.compare(data, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
     });
     it('Buffer object should not be serialized again', () => {
-        let data = SerializerUtil.serializeGrpc(Buffer.from('Hello World'));
+        const data = SerializerUtil.serializeGrpc(Buffer.from('Hello World'));
         expect(Buffer.compare(data, Buffer.from('Hello World'))).toEqual(0);
     });
 });

--- a/test/unit/utils/Serializer.util.test.ts
+++ b/test/unit/utils/Serializer.util.test.ts
@@ -16,12 +16,12 @@ import * as SerializerUtil from "../../../src/utils/Serializer.util"
 describe('serializer', () => {
     it('Object should be serialized to Buffer', () => {
         const data = SerializerUtil.serializeGrpc({ Hello: 'World' });
-        expect(Buffer.compare(data.serialized, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
+        expect(Buffer.compare(data.serializedData, Buffer.from(JSON.stringify({ Hello: 'World' })))).toEqual(0);
         expect(data.contentType).toEqual("application/json");
     });
     it('Buffer object should not be serialized again', () => {
         const data = SerializerUtil.serializeGrpc(Buffer.from('Hello World'));
-        expect(Buffer.compare(data.serialized, Buffer.from('Hello World'))).toEqual(0);
+        expect(Buffer.compare(data.serializedData, Buffer.from('Hello World'))).toEqual(0);
         expect(data.contentType).toEqual("application/octet-stream");
     });
 });


### PR DESCRIPTION
Sometimes we need to send bytes to downstream,
For example sending data with avro format to Kafka, we should not change its format anymore when it's Buffer.

Fixes #292

Signed-off-by: Alex Ji <jilichao@aliyun.com>

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly

- [x] Created/updated tests
