### PR TITLE
fix(types/http): use `import * as` http(s)

### DIFF
--- a/src/types/http/IRequest.ts
+++ b/src/types/http/IRequest.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import http from "http";
-import Restana from "restana";
+import * as http from 'http';
+import Restana from 'restana';
 
-export default interface IRequest extends http.IncomingMessage, Restana.RequestExtensions { }
+export default interface IRequest extends http.IncomingMessage, Restana.RequestExtensions {}

--- a/src/types/http/IResponse.ts
+++ b/src/types/http/IResponse.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import http from "http";
-import Restana from "restana";
+import * as http from 'http';
+import Restana from 'restana';
 
-export default interface IResponse extends http.ServerResponse, Restana.ResponseExtensions { }
+export default interface IResponse extends http.ServerResponse, Restana.ResponseExtensions {}

--- a/src/types/http/THTTPExecuteParams.type.ts
+++ b/src/types/http/THTTPExecuteParams.type.ts
@@ -11,12 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import http from "http";
-import https from "https";
+import * as http from 'http';
+import * as https from 'https';
 
 export type THTTPExecuteParams = {
   body?: string;
   headers?: { [key: string]: any };
   method: string;
   agent?: http.Agent | https.Agent;
-}
+};


### PR DESCRIPTION
Fixes "Module '"http"' has no default export" #307

Signed-off-by: Haili Zhang <haili.zhang@outlook.com>

# Description

_Please explain the changes you've made_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #307

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
