### PR TITLE
[WIP] Correct HTTP response status for subscription

### DIFF
--- a/src/enum/HttpReponseStatusForSubscription.enum.ts
+++ b/src/enum/HttpReponseStatusForSubscription.enum.ts
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/**
+ * Http Response Status to be sent back to dapr runtime as subscription response, as per 
+ * https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response
+ */
+export enum HttpResponseStatusForSubscription {
+    SUCCESS = "SUCCESS",  // Message is processed successfully
+    RETRY = "RETRY", // Message to be retried by Dapr
+    DROP = "DROP", // Warning is logged and message is dropped
+    Others = "Others" // Error, message to be retried by Dapr
+  }
+  
+  export default HttpResponseStatusForSubscription;

--- a/src/enum/SubscribedMessageHttpResponse.enum.ts
+++ b/src/enum/SubscribedMessageHttpResponse.enum.ts
@@ -15,11 +15,10 @@ limitations under the License.
  * Http Response Status to be sent back to dapr runtime as subscription response, as per 
  * https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response
  */
-export enum HttpResponseStatusForSubscription {
+export enum SubscribedMessageHttpResponse {
     SUCCESS = "SUCCESS",  // Message is processed successfully
     RETRY = "RETRY", // Message to be retried by Dapr
     DROP = "DROP", // Warning is logged and message is dropped
-    Others = "Others" // Error, message to be retried by Dapr
   }
   
-  export default HttpResponseStatusForSubscription;
+  export default SubscribedMessageHttpResponse;

--- a/src/implementation/Server/HTTPServer/pubsub.ts
+++ b/src/implementation/Server/HTTPServer/pubsub.ts
@@ -15,7 +15,7 @@ import { TypeDaprPubSubCallback } from '../../../types/DaprPubSubCallback.type';
 import IServerPubSub from '../../../interfaces/Server/IServerPubSub';
 import HTTPServer from './HTTPServer';
 import { Logger } from '../../../logger/Logger';
-import HttpResponseStatusForSubscription from '../../../enum/HttpReponseStatusForSubscription.enum';
+import SubscribedMessageHttpResponse from '../../../enum/SubscribedMessageHttpResponse.enum';
 
 // https://docs.dapr.io/reference/api/pubsub_api/
 export default class HTTPServerPubSub implements IServerPubSub {
@@ -46,13 +46,13 @@ export default class HTTPServerPubSub implements IServerPubSub {
       try {
         await cb(data);
       } catch (e) {
-        this.logger.error(`subscribe failed: ${e}`);
-        return res.send({ status: HttpResponseStatusForSubscription.RETRY });
+        this.logger.error(`[route-${topic}] Message processing failed, dropping: ${e}`);
+        return res.send({ status: SubscribedMessageHttpResponse.DROP });
       }
 
       // Let Dapr know that the message was processed correctly
       this.logger.debug(`[route-${topic}] Ack'ing the message`);
-      return res.send({ status: HttpResponseStatusForSubscription.SUCCESS });
+      return res.send({ status: SubscribedMessageHttpResponse.SUCCESS });
     });
   }
 }

--- a/src/implementation/Server/HTTPServer/pubsub.ts
+++ b/src/implementation/Server/HTTPServer/pubsub.ts
@@ -15,6 +15,8 @@ import { TypeDaprPubSubCallback } from '../../../types/DaprPubSubCallback.type';
 import IServerPubSub from '../../../interfaces/Server/IServerPubSub';
 import HTTPServer from './HTTPServer';
 import { Logger } from '../../../logger/Logger';
+import HttpResponseStatusForSubscription from '../../../enum/HttpReponseStatusForSubscription.enum';
+// import {TopicEventResponse} from '../../../proto/dapr/proto/runtime/v1/appcallback_pb'
 
 // https://docs.dapr.io/reference/api/pubsub_api/
 export default class HTTPServerPubSub implements IServerPubSub {
@@ -46,12 +48,12 @@ export default class HTTPServerPubSub implements IServerPubSub {
         await cb(data);
       } catch (e) {
         this.logger.error(`subscribe failed: ${e}`);
-        return res.send({ success: false });
+        return res.send({ status: HttpResponseStatusForSubscription.RETRY });
       }
 
       // Let Dapr know that the message was processed correctly
       this.logger.debug(`[route-${topic}] Ack'ing the message`);
-      return res.send({ success: true });
+      return res.send({ status: HttpResponseStatusForSubscription.SUCCESS });
     });
   }
 }

--- a/src/implementation/Server/HTTPServer/pubsub.ts
+++ b/src/implementation/Server/HTTPServer/pubsub.ts
@@ -16,7 +16,6 @@ import IServerPubSub from '../../../interfaces/Server/IServerPubSub';
 import HTTPServer from './HTTPServer';
 import { Logger } from '../../../logger/Logger';
 import HttpResponseStatusForSubscription from '../../../enum/HttpReponseStatusForSubscription.enum';
-// import {TopicEventResponse} from '../../../proto/dapr/proto/runtime/v1/appcallback_pb'
 
 // https://docs.dapr.io/reference/api/pubsub_api/
 export default class HTTPServerPubSub implements IServerPubSub {


### PR DESCRIPTION
Signed-off-by: Deepanshu Agarwal <deepanshu.agarwal1984@gmail.com>

# Description

This intends to fix n/ack of http response status correctly during subscription, as per https://docs.dapr.io/reference/api/pubsub_api/#expected-http-response

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #333

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
