### PR TITLE
fix: Update SDK to reflect renaming on UnlockResponse.Status (#336)

### DIFF
--- a/examples/distributedLock/README.md
+++ b/examples/distributedLock/README.md
@@ -81,7 +81,7 @@ You should see the following output from the application:
 == APP == Acquired Lock? false
 == APP == Lock cannot be acquired as it belongs to the other process
 == APP == Unlocking on redislock, resourceId as owner: owner2
-== APP == Unlock API response when lock is acquired by a different process: LockBelongToOthers
+== APP == Unlock API response when lock is acquired by a different process: LockBelongsToOthers
 == APP == Acquiring lock on redislock, resourceId as owner: owner2
 == APP == Acquired lock after the lock from the other process expired? true
 == APP == Unlocking on redislock, resourceId as owner: owner2

--- a/examples/distributedLock/TryLockApplication/src/index.ts
+++ b/examples/distributedLock/TryLockApplication/src/index.ts
@@ -39,8 +39,8 @@ async function start() {
 
   // Checking if the lock exists.
   console.log(`Unlocking on ${storeName}, ${resourceId} as owner: ${lockOwner}`);
-  const lockUnexistResponse = await client.lock.unlock(storeName, resourceId, lockOwner);
-  console.log("Unlock API response when lock is not acquired: " + getResponseStatus(lockUnexistResponse.status));
+  const lockDoesNotExistResponse = await client.lock.unlock(storeName, resourceId, lockOwner);
+  console.log("Unlock API response when lock is not acquired: " + getResponseStatus(lockDoesNotExistResponse.status));
 
   expiryInSeconds = 25;
   console.log(`Acquiring lock on ${storeName}, ${resourceId} as owner: ${lockOwner}`);
@@ -56,8 +56,8 @@ function getResponseStatus(status: LockStatus) {
       return "Success";
     case LockStatus.LockDoesNotExist: 
       return "LockDoesNotExist";
-    case LockStatus.LockBelongToOthers:
-      return "LockBelongToOthers";
+    case LockStatus.LockBelongsToOthers:
+      return "LockBelongsToOthers";
     default:
       return "InternalError";
   }

--- a/examples/distributedLock/UnLockApplication/src/index.ts
+++ b/examples/distributedLock/UnLockApplication/src/index.ts
@@ -64,8 +64,8 @@ function getResponseStatus(status: LockStatus) {
       return "Success";
     case LockStatus.LockDoesNotExist: 
       return "LockDoesNotExist";
-    case LockStatus.LockBelongToOthers:
-      return "LockBelongToOthers";
+    case LockStatus.LockBelongsToOthers:
+      return "LockBelongsToOthers";
     default:
       return "InternalError";
   }

--- a/src/implementation/Client/GRPCClient/lock.ts
+++ b/src/implementation/Client/GRPCClient/lock.ts
@@ -74,10 +74,10 @@ export default class GRPCClientLock implements IClientLock {
         switch(res.getStatus()) {
             case UnlockResponse.Status.SUCCESS:
                 return LockStatus.Success;
-            case UnlockResponse.Status.LOCK_UNEXIST:
+            case UnlockResponse.Status.LOCK_DOES_NOT_EXIST:
                 return LockStatus.LockDoesNotExist;
-            case UnlockResponse.Status.LOCK_BELONG_TO_OTHERS:
-                return LockStatus.LockBelongToOthers;
+            case UnlockResponse.Status.LOCK_BELONGS_TO_OTHERS:
+                return LockStatus.LockBelongsToOthers;
             default:
                 return LockStatus.InternalError;
 

--- a/src/proto/dapr/proto/runtime/v1/dapr.proto
+++ b/src/proto/dapr/proto/runtime/v1/dapr.proto
@@ -589,8 +589,8 @@ message UnlockRequest {
 message UnlockResponse {
   enum Status {
     SUCCESS = 0;
-    LOCK_UNEXIST = 1;
-    LOCK_BELONG_TO_OTHERS = 2;
+    LOCK_DOES_NOT_EXIST = 1;
+    LOCK_BELONGS_TO_OTHERS = 2;
     INTERNAL_ERROR = 3;
   }
 

--- a/src/proto/dapr/proto/runtime/v1/dapr_pb.d.ts
+++ b/src/proto/dapr/proto/runtime/v1/dapr_pb.d.ts
@@ -1320,8 +1320,8 @@ export namespace UnlockResponse {
 
     export enum Status {
     SUCCESS = 0,
-    LOCK_UNEXIST = 1,
-    LOCK_BELONG_TO_OTHERS = 2,
+    LOCK_DOES_NOT_EXIST = 1,
+    LOCK_BELONGS_TO_OTHERS = 2,
     INTERNAL_ERROR = 3,
     }
 

--- a/src/proto/dapr/proto/runtime/v1/dapr_pb.js
+++ b/src/proto/dapr/proto/runtime/v1/dapr_pb.js
@@ -10645,8 +10645,8 @@ proto.dapr.proto.runtime.v1.UnlockResponse.serializeBinaryToWriter = function(me
  */
 proto.dapr.proto.runtime.v1.UnlockResponse.Status = {
   SUCCESS: 0,
-  LOCK_UNEXIST: 1,
-  LOCK_BELONG_TO_OTHERS: 2,
+  LOCK_DOES_NOT_EXIST: 1,
+  LOCK_BELONGS_TO_OTHERS: 2,
   INTERNAL_ERROR: 3
 };
 

--- a/src/types/lock/UnlockResponse.ts
+++ b/src/types/lock/UnlockResponse.ts
@@ -14,7 +14,7 @@ limitations under the License.
 export enum LockStatus {
     Success,
     LockDoesNotExist,
-    LockBelongToOthers,
+    LockBelongsToOthers,
     InternalError
 }
 

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -504,7 +504,7 @@ describe('grpc/client', () => {
       const tryLockOne = await client.lock.tryLock("redislock", resourceId, "owner5", 5);
       expect(tryLockOne.success).toEqual(true);
       const unlock = await client.lock.unlock("redislock", resourceId, "owner6");
-      expect(unlock.status).toEqual(LockStatus.LockBelongToOthers);
+      expect(unlock.status).toEqual(LockStatus.LockBelongsToOthers);
     });
   });
 });


### PR DESCRIPTION
# Description

_Please explain the changes you've made_

PR dapr/dapr#4989 (issue dapr/dapr#4988) updated the names of some
enums in `UnlockResponse.Status` ProtoBuff definition:

* `LOCK_UNEXIST` became `LOCK_DOES_NOT_EXIST `
* `LOCK_BELONG_TO_OTHERS`  became `LOCK_BELONGS_TO_OTHERS`

Code in clients SDKs needs to be updated to account for this modification.

This PR accomplishes this by updating:
1. the generated gRPC Protobuf client and
2. the SDK code and tests.

Fixes dapr/js-sdk#336


## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #336 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [x] Code compiles correctly
* [x] Created/updated tests
* [x] Extended the documentation
