### PR TITLE
Propagate logger to sidecar awaiting method

### DIFF
--- a/src/implementation/Client/DaprClient.ts
+++ b/src/implementation/Client/DaprClient.ts
@@ -149,9 +149,7 @@ export default class DaprClient {
     return new DaprClient(client.getClientHost(), client.getClientPort(), client.getClientCommunicationProtocol(), client.getOptions());
   }
 
-  static async awaitSidecarStarted(fnIsSidecarStarted: () => Promise<boolean>): Promise<void> {
-    const logger = new Logger("DaprClient", "DaprClient");
-
+  static async awaitSidecarStarted(fnIsSidecarStarted: () => Promise<boolean>, logger: Logger): Promise<void> {
     // Dapr will probe every 50ms to see if we are listening on our port: https://github.com/dapr/dapr/blob/a43712c97ead550ca2f733e9f7e7769ecb195d8b/pkg/runtime/runtime.go#L1694
     // if we are using actors we will change this to 4s to let the placement tables update
     let isStarted = await fnIsSidecarStarted();

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -115,7 +115,7 @@ export default class GRPCClient implements IClient {
   }
 
   async _startAwaitSidecarStarted(): Promise<void> {
-    await DaprClient.awaitSidecarStarted(async () => await GRPCClientSidecar.isStarted(this));
+    await DaprClient.awaitSidecarStarted(async () => await GRPCClientSidecar.isStarted(this), this.logger);
   }
 
   /**

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -113,7 +113,7 @@ export default class HTTPClient implements IClient {
   }
 
   async _startAwaitSidecarStarted(): Promise<void> {
-    await DaprClient.awaitSidecarStarted(async () => await HTTPClientSidecar.isStarted(this));
+    await DaprClient.awaitSidecarStarted(async () => await HTTPClientSidecar.isStarted(this), this.logger);
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

# Description

Logger options were not being sent to one method, causing it to use the default one. This PR fixes it.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #354

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [X] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
