### PR TITLE
feat: report SDK version in user-agent

### DIFF
--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -20,6 +20,7 @@ import { Settings } from "../../../utils/Settings.util";
 import { Logger } from "../../../logger/Logger";
 import GRPCClientSidecar from "./sidecar";
 import DaprClient from "../DaprClient";
+import { SDK_VERSION } from "../../../version";
 
 export default class GRPCClient implements IClient {
   private isInitialized: boolean;
@@ -69,7 +70,9 @@ export default class GRPCClient implements IClient {
   }
 
   private generateClient(host: string, port: string, credentials: grpc.ChannelCredentials): GrpcDaprClient {
-    const client = new GrpcDaprClient(`${host}:${port}`, credentials);
+    const client = new GrpcDaprClient(`${host}:${port}`, credentials, {
+      "grpc.primary_user_agent": "dapr-sdk-js/v" + SDK_VERSION,
+    });
     return client;
   }
 

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -21,6 +21,7 @@ import { Settings } from "../../../utils/Settings.util";
 import { THTTPExecuteParams } from "../../../types/http/THTTPExecuteParams.type";
 import { Logger } from "../../../logger/Logger";
 import HTTPClientSidecar from "./sidecar";
+import { SDK_VERSION } from "../../../version";
 
 export default class HTTPClient implements IClient {
   private isInitialized: boolean;
@@ -156,6 +157,8 @@ export default class HTTPClient implements IClient {
     if (this.options.daprApiToken) {
       params.headers["dapr-api-token"] = this.options.daprApiToken;
     }
+
+    params.headers["user-agent"] = `dapr-sdk-js/v${SDK_VERSION} http/1`;
 
     if (!params?.method) {
       params.method = "GET";


### PR DESCRIPTION
# Description

This change updates the user-agent header (and equivalent metadata for gRPC) to include the version of the SDK.

HTTP example:

> INFO[0001] HTTP API Called: GET /v1.0/metadata     app_id=example-http-pubsub instance=mbp.local scope=dapr.runtime.http-info type=log useragent="dapr-sdk-js/v2.4.2 http/1" ver=1.9.0-rc.3

gRPC example:

> INFO[0001] gRPC API Called: /dapr.proto.runtime.v1.Dapr/InvokeBinding  app_id=example-hello-world instance=mbp.local scope=dapr.runtime.grpc.api-info type=log useragent="dapr-sdk-js/v2.4.2 grpc-node-js/1.5.0" ver=1.9.0-rc.3

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
