### PR TITLE
feat(invocation): Allow sending and receiving headers during HTTP service invocation

### DIFF
--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -129,8 +129,12 @@ async function start() {
   const response = await client.invoker.invoke(serviceAppId, serviceMethod, HttpMethod.POST, { hello: "world" });
 
   // POST Request with headers
-  const response = await client.invoker.invoke(serviceAppId, serviceMethod, HttpMethod.POST, { hello: "world" }, 
-    { headers: { "X-User-ID": "123" }}
+  const response = await client.invoker.invoke(
+    serviceAppId,
+    serviceMethod,
+    HttpMethod.POST,
+    { hello: "world" },
+    { headers: { "X-User-ID": "123" } },
   );
 
   // GET Request

--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -128,6 +128,11 @@ async function start() {
   // POST Request
   const response = await client.invoker.invoke(serviceAppId, serviceMethod, HttpMethod.POST, { hello: "world" });
 
+  // POST Request with headers
+  const response = await client.invoker.invoke(serviceAppId, serviceMethod, HttpMethod.POST, { hello: "world" }, 
+    { headers: { "X-User-ID": "123" }}
+  );
+
   // GET Request
   const response = await client.invoker.invoke(serviceAppId, serviceMethod, HttpMethod.GET);
 }

--- a/daprdocs/content/en/js-sdk-docs/js-server/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-server/_index.md
@@ -98,7 +98,7 @@ The JavaScript Server SDK allows you to interface with all of the [Dapr building
 #### Listen to an Invocation
 
 ```typescript
-import { DaprServer } from "@dapr/dapr";
+import { DaprServer, DaprInvokerCallbackContent } from "@dapr/dapr";
 
 const daprHost = "127.0.0.1"; // Dapr Sidecar Host
 const daprPort = "3500"; // Dapr Sidecar Port of this Example Server
@@ -108,7 +108,14 @@ const serverPort = "50051"; // App Port of this Example Server "
 async function start() {
   const server = new DaprServer(serverHost, serverPort, daprHost, daprPort);
 
-  await server.invoker.listen("hello-world", mock, { method: HttpMethod.GET });
+  const callbackFunction = (data: DaprInvokerCallbackContent) => {
+    console.log("Received body: ", data.body);
+    console.log("Received metadata: ", data.metadata);
+    console.log("Received query: ", data.query);
+    console.log("Received headers: ", data.headers); // only available in HTTP
+  };
+
+  await server.invoker.listen("hello-world", callbackFunction, { method: HttpMethod.GET });
 
   // You can now invoke the service with your app id and method "hello-world"
 

--- a/examples/invocation/src/index.ts
+++ b/examples/invocation/src/index.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { DaprServer, DaprClient, HttpMethod, DaprInvokerCallbackContent, CommunicationProtocolEnum } from "@dapr/dapr";
+import { DaprServer, DaprClient, HttpMethod, DaprInvokerCallbackContent } from "@dapr/dapr";
 
 // Common settings
 const daprAppId = "example-invocation";

--- a/examples/invocation/src/index.ts
+++ b/examples/invocation/src/index.ts
@@ -51,9 +51,13 @@ async function start() {
   await new Promise((resolve) => setTimeout(resolve, 500));
 
   console.log("Invoking endpoints");
-  const r = await client.invoker.invoke(daprAppId, "hello-world", HttpMethod.POST,
+  const r = await client.invoker.invoke(
+    daprAppId,
+    "hello-world",
+    HttpMethod.POST,
     { hello: "world" },
-    { headers: { 'X-Application-Type': 'examples/invocation' } });
+    { headers: { "X-Application-Type": "examples/invocation" } },
+  );
   console.log(`Response to POST request: ${JSON.stringify(r)}`);
   const r2 = await client.invoker.invoke(daprAppId, "hello-world", HttpMethod.GET);
   console.log(`Response to GET request: ${JSON.stringify(r2)}`);

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -18,7 +18,6 @@ import { HttpMethod } from "../../../enum/HttpMethod.enum";
 import { HTTPExtension, InvokeRequest, InvokeResponse } from "../../../proto/dapr/proto/common/v1/common_pb";
 import { InvokeServiceRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import * as HttpVerbUtil from "../../../utils/HttpVerb.util";
-
 import IClientInvoker from "../../../interfaces/Client/IClientInvoker";
 import * as SerializerUtil from "../../../utils/Serializer.util";
 import { InvokerOptions } from "../../../types/InvokerOptions.type";
@@ -52,7 +51,7 @@ export default class GRPCClientInvoker implements IClientInvoker {
       fetchOptions.headers["Content-Type"] = "application/json";
     }
 
-    if (method !== HttpMethod.GET && data !== undefined) {
+    if (method !== HttpMethod.GET) {
       //@ts-ignore
       fetchOptions.body = JSON.stringify(data);
     }

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -37,25 +37,8 @@ export default class GRPCClientInvoker implements IClientInvoker {
     methodName: string,
     method: HttpMethod = HttpMethod.GET,
     data: object = {},
-    options: InvokerOptions = {},
+    _options: InvokerOptions = {},
   ): Promise<object> {
-    const headers = options.headers ?? {};
-
-    const fetchOptions = {
-      method,
-      headers,
-    };
-
-    if (method !== HttpMethod.GET) {
-      //@ts-ignore
-      fetchOptions.headers["Content-Type"] = "application/json";
-    }
-
-    if (method !== HttpMethod.GET) {
-      //@ts-ignore
-      fetchOptions.body = JSON.stringify(data);
-    }
-
     // InvokeServiceRequest represents the request message for Service invocation.
     const msgInvokeService = new InvokeServiceRequest();
     msgInvokeService.setId(appId);

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -36,7 +36,7 @@ export default class GRPCClientInvoker implements IClientInvoker {
     appId: string,
     methodName: string,
     method: HttpMethod = HttpMethod.GET,
-    data?: object,
+    data: object = {},
     options: InvokerOptions = {},
   ): Promise<object> {
     const headers = options.headers ?? {};

--- a/src/implementation/Client/HTTPClient/invoker.ts
+++ b/src/implementation/Client/HTTPClient/invoker.ts
@@ -35,7 +35,6 @@ export default class HTTPClientInvoker implements IClientInvoker {
 
     const fetchOptions = {
       method,
-
       headers,
     };
 

--- a/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
+++ b/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
@@ -28,7 +28,6 @@ import {
   TopicRule,
   TopicSubscription,
 } from "../../../proto/dapr/proto/runtime/v1/appcallback_pb";
-import { TypeDaprInvokerCallback } from "../../../types/DaprInvokerCallback.type";
 import * as HttpVerbUtil from "../../../utils/HttpVerb.util";
 import { TypeDaprBindingCallback } from "../../../types/DaprBindingCallback.type";
 import { TypeDaprPubSubCallback } from "../../../types/DaprPubSubCallback.type";
@@ -39,6 +38,7 @@ import { IServerType } from "./GRPCServer";
 import { PubSubSubscriptionsType } from "../../../types/pubsub/PubSubSubscriptions.type";
 import { DaprPubSubType } from "../../../types/pubsub/DaprPubSub.type";
 import { PubSubSubscriptionTopicRoutesType } from "../../../types/pubsub/PubSubSubscriptionTopicRoutes.type";
+import { DaprInvokerCallbackFunction } from "../../../types/DaprInvokerCallback.type";
 
 // https://github.com/badsyntax/grpc-js-typescript/issues/1#issuecomment-705419742
 // @ts-ignore
@@ -48,7 +48,7 @@ export default class GRPCServerImpl implements IAppCallbackServer {
   private readonly logger: Logger;
   private readonly server: IServerType;
 
-  handlersInvoke: { [key: string]: TypeDaprInvokerCallback };
+  handlersInvoke: { [key: string]: DaprInvokerCallbackFunction };
   handlersBindings: { [key: string]: TypeDaprBindingCallback };
   pubSubSubscriptions: PubSubSubscriptionsType;
 
@@ -73,7 +73,7 @@ export default class GRPCServerImpl implements IAppCallbackServer {
     return `${httpMethod.toLowerCase()}|${methodName.toLowerCase()}`;
   }
 
-  registerOnInvokeHandler(httpMethod: string, methodName: string, cb: TypeDaprInvokerCallback): void {
+  registerOnInvokeHandler(httpMethod: string, methodName: string, cb: DaprInvokerCallbackFunction): void {
     const handlerKey = this.createOnInvokeHandlerKey(httpMethod, methodName);
     this.handlersInvoke[handlerKey] = cb;
   }
@@ -313,7 +313,7 @@ export default class GRPCServerImpl implements IAppCallbackServer {
     return `${pubsubName.toLowerCase()}--${topic.toLowerCase()}--${routeParsed}`;
   }
 
-  registerInputBindingHandler(bindingName: string, cb: TypeDaprInvokerCallback): void {
+  registerInputBindingHandler(bindingName: string, cb: DaprInvokerCallbackFunction): void {
     const handlerKey = this.createInputBindingHandlerKey(bindingName);
     this.handlersBindings[handlerKey] = cb;
   }

--- a/src/implementation/Server/GRPCServer/invoker.ts
+++ b/src/implementation/Server/GRPCServer/invoker.ts
@@ -12,11 +12,11 @@ limitations under the License.
 */
 
 import GRPCServer from "./GRPCServer";
-import { TypeDaprInvokerCallback } from "../../../types/DaprInvokerCallback.type";
 import { InvokerListenOptionsType } from "../../../types/InvokerListenOptions.type";
 import { HttpMethod } from "../../../enum/HttpMethod.enum";
 import IServerInvoker from "../../../interfaces/Server/IServerInvoker";
 import { Logger } from "../../../logger/Logger";
+import { DaprInvokerCallbackFunction } from "../../../types/DaprInvokerCallback.type";
 
 // https://docs.dapr.io/reference/api/service_invocation_api/
 export default class DaprInvoker implements IServerInvoker {
@@ -28,7 +28,7 @@ export default class DaprInvoker implements IServerInvoker {
     this.logger = new Logger("GRPCServer", "Invoker", server.client.options.logger);
   }
 
-  async listen(methodName: string, cb: TypeDaprInvokerCallback, options: InvokerListenOptionsType = {}): Promise<any> {
+  async listen(methodName: string, cb: DaprInvokerCallbackFunction, options: InvokerListenOptionsType = {}): Promise<any> {
     const httpMethod: HttpMethod = (options?.method?.toLowerCase() as HttpMethod) || HttpMethod.GET;
     this.logger.info(`Registering onInvoke Handler ${httpMethod} /${methodName}`);
     this.server.getServerImpl().registerOnInvokeHandler(httpMethod, methodName, cb);

--- a/src/implementation/Server/GRPCServer/invoker.ts
+++ b/src/implementation/Server/GRPCServer/invoker.ts
@@ -28,7 +28,11 @@ export default class DaprInvoker implements IServerInvoker {
     this.logger = new Logger("GRPCServer", "Invoker", server.client.options.logger);
   }
 
-  async listen(methodName: string, cb: DaprInvokerCallbackFunction, options: InvokerListenOptionsType = {}): Promise<any> {
+  async listen(
+    methodName: string,
+    cb: DaprInvokerCallbackFunction,
+    options: InvokerListenOptionsType = {},
+  ): Promise<any> {
     const httpMethod: HttpMethod = (options?.method?.toLowerCase() as HttpMethod) || HttpMethod.GET;
     this.logger.info(`Registering onInvoke Handler ${httpMethod} /${methodName}`);
     this.server.getServerImpl().registerOnInvokeHandler(httpMethod, methodName, cb);

--- a/src/implementation/Server/HTTPServer/invoker.ts
+++ b/src/implementation/Server/HTTPServer/invoker.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TypeDaprInvokerCallback } from "../../../types/DaprInvokerCallback.type";
+import { DaprInvokerCallbackFunction } from "../../../types/DaprInvokerCallback.type";
 import { InvokerListenOptionsType } from "../../../types/InvokerListenOptions.type";
 import { HttpMethod } from "../../../enum/HttpMethod.enum";
 import HTTPServer from "./HTTPServer";
@@ -28,7 +28,7 @@ export default class HTTPServerInvoker implements IServerInvoker {
     this.logger = new Logger("HTTPServer", "Invoker", server.client.options.logger);
   }
 
-  async listen(methodName: string, cb: TypeDaprInvokerCallback, options: InvokerListenOptionsType = {}) {
+  async listen(methodName: string, cb: DaprInvokerCallbackFunction, options: InvokerListenOptionsType = {}) {
     const serverMethod: HttpMethod = (options?.method?.toLowerCase() as HttpMethod) || HttpMethod.GET;
 
     const server = await this.server.getServer();

--- a/src/implementation/Server/HTTPServer/invoker.ts
+++ b/src/implementation/Server/HTTPServer/invoker.ts
@@ -32,7 +32,6 @@ export default class HTTPServerInvoker implements IServerInvoker {
     const serverMethod: HttpMethod = (options?.method?.toLowerCase() as HttpMethod) || HttpMethod.GET;
 
     const server = await this.server.getServer();
-    // @TODO should pass rest of headers to callback
     server[serverMethod](`/${methodName}`, async (req, res) => {
       const invokeResponse = await cb({
         body: JSON.stringify(req.body),
@@ -40,6 +39,7 @@ export default class HTTPServerInvoker implements IServerInvoker {
         metadata: {
           contentType: req.headers["content-type"],
         },
+        headers: req.headers,
       });
 
       // Make sure we close the request after the callback

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import { ConsoleLoggerService } from "./logger/ConsoleLoggerService";
 import { LogLevel } from "./types/logger/LogLevel";
 import GRPCClient from "./implementation/Client/GRPCClient/GRPCClient";
 import HTTPClient from "./implementation/Client/HTTPClient/HTTPClient";
-
+import { InvokerOptions } from "./types/InvokerOptions.type";
 export {
   DaprClient,
   DaprServer,
@@ -43,4 +43,5 @@ export {
   LoggerOptions,
   LoggerService,
   ConsoleLoggerService,
+  InvokerOptions,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import { LogLevel } from "./types/logger/LogLevel";
 import GRPCClient from "./implementation/Client/GRPCClient/GRPCClient";
 import HTTPClient from "./implementation/Client/HTTPClient/HTTPClient";
 import { InvokerOptions } from "./types/InvokerOptions.type";
-import { DaprInvokerCallbackContent, DaprInvokerCallbackResponse } from "./types/DaprInvokerCallback.type";
+import { DaprInvokerCallbackContent, DaprInvokerCallbackFunction } from "./types/DaprInvokerCallback.type";
 export {
   DaprClient,
   DaprServer,
@@ -45,6 +45,6 @@ export {
   LoggerService,
   ConsoleLoggerService,
   InvokerOptions,
-  DaprInvokerCallbackResponse as TypeDaprInvokerCallback,
+  DaprInvokerCallbackFunction as TypeDaprInvokerCallback,
   DaprInvokerCallbackContent,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { LogLevel } from "./types/logger/LogLevel";
 import GRPCClient from "./implementation/Client/GRPCClient/GRPCClient";
 import HTTPClient from "./implementation/Client/HTTPClient/HTTPClient";
 import { InvokerOptions } from "./types/InvokerOptions.type";
+import { DaprInvokerCallbackContent, DaprInvokerCallbackResponse } from "./types/DaprInvokerCallback.type";
 export {
   DaprClient,
   DaprServer,
@@ -44,4 +45,6 @@ export {
   LoggerService,
   ConsoleLoggerService,
   InvokerOptions,
+  DaprInvokerCallbackResponse as TypeDaprInvokerCallback,
+  DaprInvokerCallbackContent,
 };

--- a/src/interfaces/Client/IClientInvoker.ts
+++ b/src/interfaces/Client/IClientInvoker.ts
@@ -12,7 +12,8 @@ limitations under the License.
 */
 
 import { HttpMethod } from "../../enum/HttpMethod.enum";
+import { InvokerOptions } from "../../types/InvokerOptions.type";
 
 export default interface IClientInvoker {
-  invoke(appId: string, methodName: string, method: HttpMethod, data?: object): Promise<object>;
+  invoke(appId: string, methodName: string, method: HttpMethod, data?: object, options?: InvokerOptions): Promise<object>;
 }

--- a/src/interfaces/Client/IClientInvoker.ts
+++ b/src/interfaces/Client/IClientInvoker.ts
@@ -15,5 +15,11 @@ import { HttpMethod } from "../../enum/HttpMethod.enum";
 import { InvokerOptions } from "../../types/InvokerOptions.type";
 
 export default interface IClientInvoker {
-  invoke(appId: string, methodName: string, method: HttpMethod, data?: object, options?: InvokerOptions): Promise<object>;
+  invoke(
+    appId: string,
+    methodName: string,
+    method: HttpMethod,
+    data?: object,
+    options?: InvokerOptions,
+  ): Promise<object>;
 }

--- a/src/interfaces/Server/IServerInvoker.ts
+++ b/src/interfaces/Server/IServerInvoker.ts
@@ -11,9 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { TypeDaprInvokerCallback } from "../../types/DaprInvokerCallback.type";
+import { DaprInvokerCallbackFunction } from "../../types/DaprInvokerCallback.type";
 import { InvokerListenOptionsType } from "../../types/InvokerListenOptions.type";
 
 export default interface IServerInvoker {
-  listen(methodName: string, cb: TypeDaprInvokerCallback, options?: InvokerListenOptionsType): Promise<any>;
+  listen(methodName: string, cb: DaprInvokerCallbackFunction, options?: InvokerListenOptionsType): Promise<any>;
 }

--- a/src/types/DaprInvokerCallback.type.ts
+++ b/src/types/DaprInvokerCallback.type.ts
@@ -41,4 +41,4 @@ export interface DaprInvokerCallbackContent {
   headers?: KeyValueType;
 }
 
-export type TypeDaprInvokerCallback = (data: DaprInvokerCallbackContent) => Promise<any | void>;
+export type DaprInvokerCallbackResponse = (data: DaprInvokerCallbackContent) => Promise<any | void>;

--- a/src/types/DaprInvokerCallback.type.ts
+++ b/src/types/DaprInvokerCallback.type.ts
@@ -41,4 +41,4 @@ export interface DaprInvokerCallbackContent {
   headers?: KeyValueType;
 }
 
-export type DaprInvokerCallbackResponse = (data: DaprInvokerCallbackContent) => Promise<any | void>;
+export type DaprInvokerCallbackFunction = (data: DaprInvokerCallbackContent) => Promise<any | void>;

--- a/src/types/DaprInvokerCallback.type.ts
+++ b/src/types/DaprInvokerCallback.type.ts
@@ -11,14 +11,34 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { KeyValueType } from "./KeyValue.type";
+
 export interface DaprInvokerCallbackContentMetadata {
   contentType?: string;
 }
 
 export interface DaprInvokerCallbackContent {
+  /**
+   * The body of invocation request from the response.
+   */
   body?: string;
+
+  /**
+   * In HTTP, this represents the HTTP URL of the request.
+   * In gRPC, this represents the HTTP querystring from the gRPC request.
+   */
   query?: string;
+
+  /**
+   * Metadata related to the invocation request.
+   */
   metadata?: DaprInvokerCallbackContentMetadata;
+
+  /**
+   * HTTP headers from the response.
+   * Note, this is ignored when using the gRPC protocol.
+   */
+  headers?: KeyValueType;
 }
 
 export type TypeDaprInvokerCallback = (data: DaprInvokerCallbackContent) => Promise<any | void>;

--- a/src/types/InvokerOptions.type.ts
+++ b/src/types/InvokerOptions.type.ts
@@ -11,12 +11,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { KeyValueType } from "./KeyValue.type";
+
 /**
  * Options related to service invocation.
  */
 export type InvokerOptions = {
   /**
-   * Headers to include in service invocation request.
+   * Headers to include in the service invocation request.
+   * Note, this is ignored when using the gRPC protocol.
    */
-  headers?: object;
+  headers?: KeyValueType;
 };

--- a/test/e2e/http/server.test.ts
+++ b/test/e2e/http/server.test.ts
@@ -433,9 +433,9 @@ describe("http/server", () => {
       const mock = jest.fn(async (data: DaprInvokerCallbackContent) => data.headers);
 
       await server.invoker.listen("hello-world-headers", mock, { method: HttpMethod.GET });
-      const res = await server.client.invoker.invoke(daprAppId, "hello-world-headers", HttpMethod.GET, undefined,
-        { headers: { "x-foo": "bar-baz" } }
-      );
+      const res = await server.client.invoker.invoke(daprAppId, "hello-world-headers", HttpMethod.GET, undefined, {
+        headers: { "x-foo": "bar-baz" },
+      });
 
       // Delay a bit for event to arrive
       await new Promise((resolve, _reject) => setTimeout(resolve, 250));

--- a/test/e2e/http/server.test.ts
+++ b/test/e2e/http/server.test.ts
@@ -12,6 +12,8 @@ limitations under the License.
 */
 
 import { CommunicationProtocolEnum, DaprServer, HttpMethod } from "../../../src";
+import { DaprInvokerCallbackContent } from "../../../src/types/DaprInvokerCallback.type";
+import { KeyValueType } from "../../../src/types/KeyValue.type";
 
 const serverHost = "127.0.0.1";
 const serverPort = "50001";
@@ -425,6 +427,22 @@ describe("http/server", () => {
 
       expect(mock.mock.calls.length).toBe(1);
       expect(JSON.stringify(res)).toEqual(`{"hello":"world"}`);
+    });
+
+    it("should be able to listen and invoke a service with headers", async () => {
+      const mock = jest.fn(async (data: DaprInvokerCallbackContent) => data.headers);
+
+      await server.invoker.listen("hello-world-headers", mock, { method: HttpMethod.GET });
+      const res = await server.client.invoker.invoke(daprAppId, "hello-world-headers", HttpMethod.GET, undefined,
+        { headers: { "x-foo": "bar-baz" } }
+      );
+
+      // Delay a bit for event to arrive
+      await new Promise((resolve, _reject) => setTimeout(resolve, 250));
+
+      expect(mock.mock.calls.length).toBe(1);
+      const headers = res as KeyValueType;
+      expect(headers["x-foo"]).toEqual("bar-baz");
     });
   });
 });


### PR DESCRIPTION
# Description

This PR adds the option to send and receive headers while doing service invocation over HTTP.

1. `InvokerOptions` are now an optional contract in `IClientInvoker`, which contains `headers` for HTTP.
2. `DaprInvokerCallbackType` includes an optional header field now.
3. In gRPC client invoker, `fetchOptions` was not being used, it's removed.
4. Export `DaprInvokerCallbackFunction` and `DaprInvokerCallbackContent`

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/js-sdk#218


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [ ] Extended the documentation