### PR TITLE
fix when the invoker experience 404 it throws empty error 

### DIFF
--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -206,8 +206,16 @@ export default class HTTPClient implements IClient {
 
     // All the others
     else {
-      this.logger.debug("Execute response text: %s", txtParsed);
-      throw new Error(JSON.stringify({ status: res.status, originError: txtParsed }));
+      this.logger.debug(`Execute response with  status: ${res.status} and text: ${txtParsed}`);
+      throw new Error(
+        JSON.stringify({
+          error: "UNKNOWN",
+          error_msg: `An unknown problem occurred and we got the status ${res.status} with response ${JSON.stringify(
+            res,
+          )}`,
+          status: res.status,
+        }),
+      );
     }
   }
 }

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -203,29 +203,11 @@ export default class HTTPClient implements IClient {
     if (res.status >= 200 && res.status <= 399) {
       return txtParsed;
     }
-    // 400 = Bad Request, 401 = Unauthorized, 404 = Not Found
-    else if (res.status === 400 || res.status === 401 || res.status === 404) {
-      throw new Error(JSON.stringify(txtParsed));
-    }
-    // 403 = Forbidden
-    else if (res.status === 403) {
-      throw new Error(JSON.stringify(txtParsed));
-    }
-    // 500 = Internal Server Error, 502 = Bad Gateway
-    else if (res.status === 500 || res.status === 502) {
-      throw new Error(JSON.stringify(txtParsed));
-    }
+   
     // All the others
     else {
       this.logger.debug("Execute response text: %s", txtParsed);
-      throw new Error(
-        JSON.stringify({
-          error: "UNKNOWN",
-          error_msg: `An unknown problem occured and we got the status ${res.status} with response ${JSON.stringify(
-            res,
-          )}`,
-        }),
-      );
+      throw new Error(JSON.stringify({ status: res.status, originError: txtParsed }));
     }
   }
 }

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -203,7 +203,7 @@ export default class HTTPClient implements IClient {
     if (res.status >= 200 && res.status <= 399) {
       return txtParsed;
     }
-   
+
     // All the others
     else {
       this.logger.debug("Execute response text: %s", txtParsed);


### PR DESCRIPTION
# Description

Fix when the invoker experience 404 it throws empty error.

```js
    // 2XX -> OK; 3XX -> Redirects and Found
    if (res.status >= 200 && res.status <= 399) {
      return txtParsed;
    }

    // All the others
    else {
      this.logger.debug("Execute response text: %s", txtParsed);
      throw new Error(JSON.stringify({ status: res.status, originError: txtParsed }));
    }
```
All the  error status handled in one condition.

## Issue reference

Please reference the issue this PR will close: #296 


## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation