### PR TITLE
[WIP] breaking(): Deprecate req.body.data in favor of req.body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 3.x release
+
+### v3.0.0
+
+#### Breaking Changes
+
+##### PUBSUB: `req.body` is being returned now instead of `req.body.data`
+
+We decided to change the way the `req.body` is being returned in the `DaprServer` class. Instead of returning `req.body.data` we now return `req.body`. 
+
+This means that in the example below 
+
+```javascript
+await server.pubsub.subscribe(pubSubName, topic, async (body: any, headers: object) =>
+console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`),
+);
+```
+
+You will have to change `body` to utilize the `data` property. 
+
+```javascript
+await server.pubsub.subscribe(pubSubName, topic, async (body: any, headers: object) =>
+console.log(`Received Data: ${JSON.stringify(body.data)} with headers: ${JSON.stringify(headers)}`),
+);
+```
+
 ## 2.x release
 
 ### v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,21 @@
 
 ##### PUBSUB: `req.body` is being returned now instead of `req.body.data`
 
-We decided to change the way the `req.body` is being returned in the `DaprServer` class. Instead of returning `req.body.data` we now return `req.body`. 
+We decided to change the way the `req.body` is being returned in the `DaprServer` class. Instead of returning `req.body.data` we now return `req.body`.
 
-This means that in the example below 
+This means that in the example below
 
 ```javascript
 await server.pubsub.subscribe(pubSubName, topic, async (body: any, headers: object) =>
-console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`),
+  console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`),
 );
 ```
 
-You will have to change `body` to utilize the `data` property. 
+You will have to change `body` to utilize the `data` property.
 
 ```javascript
 await server.pubsub.subscribe(pubSubName, topic, async (body: any, headers: object) =>
-console.log(`Received Data: ${JSON.stringify(body.data)} with headers: ${JSON.stringify(headers)}`),
+  console.log(`Received Data: ${JSON.stringify(body.data)} with headers: ${JSON.stringify(headers)}`),
 );
 ```
 

--- a/daprdocs/content/en/js-sdk-docs/js-server/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-server/_index.md
@@ -140,7 +140,7 @@ Subscribing to messages can be done in several ways to offer flexibility of rece
 - Direct susbcription with options through the `subscribeWithOptions` method
 - Subscription afterwards through the `susbcribeOnEvent` method
 
-Each time an event arrives, we pass its body as `data` and the headers as `headers`, which can contain properties of the event publisher (e.g., a device ID from IoT Hub)
+Each time an event arrives, we pass its body as `body` and the headers as `headers`, which can contain properties of the event publisher (e.g., a device ID from IoT Hub)
 
 > Dapr requires subscriptions to be set up on startup, but in the JS SDK we allow event handlers to be added afterwards as well, providing you the flexibility of programming.
 
@@ -162,21 +162,21 @@ async function start() {
 
   // Configure Subscriber for a Topic
   // Method 1: Direct subscription through the `subscribe` method
-  await server.pubsub.subscribe(pubSubName, topic, async (data: any, headers: object) =>
-    console.log(`Received Data: ${JSON.stringify(data)} with headers: ${JSON.stringify(headers)}`),
+  await server.pubsub.subscribe(pubSubName, topic, async (body: any, headers: object) =>
+    console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`),
   );
 
   // Method 2: Direct susbcription with options through the `subscribeWithOptions` method
   await server.pubsub.subscribeWithOptions(pubSubName, topic, {
-    callback: async (data: any, headers: object) =>
-      console.log(`Received Data: ${JSON.stringify(data)} with headers: ${JSON.stringify(headers)}`),
+    callback: async (body: any, headers: object) =>
+      console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`),
   });
 
   // Method 3: Subscription afterwards through the `susbcribeOnEvent` method
   // Note: we use default, since if no route was passed (empty options) we utilize "default" as the route name
   await server.pubsub.subscribeWithOptions("pubsub-redis", "topic-options-1", {});
-  server.pubsub.subscribeToRoute("pubsub-redis", "topic-options-1", "default", async (data: any, headers: object) => {
-    console.log(`Received Data: ${JSON.stringify(data)} with headers: ${JSON.stringify(headers)}`);
+  server.pubsub.subscribeToRoute("pubsub-redis", "topic-options-1", "default", async (body: any, headers: object) => {
+    console.log(`Received Data: ${JSON.stringify(body)} with headers: ${JSON.stringify(headers)}`);
   });
 
   // Start the server
@@ -223,13 +223,13 @@ async function start() {
   });
 
   // Add handlers for each route
-  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "default", async (data) => {
+  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "default", async (body) => {
     console.log(`Handling Default`);
   });
-  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "type-1", async (data) => {
+  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "type-1", async (body) => {
     console.log(`Handling Type 1`);
   });
-  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "type-2", async (data) => {
+  server.pubsub.subscribeToRoute("pubsub-redis", "topic-1", "type-2", async (body) => {
     console.log(`Handling Type 2`);
   });
 

--- a/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
@@ -88,7 +88,7 @@ export default class HTTPServerImpl {
         // Parse the data of the body, we prioritize fetching the data key in body if possible
         // i.e. Redis returns { data: {} } and other services return {}
         // @todo: This will be deprecated in an upcoming major version and only req.body will be returned
-        const data = req?.body?.data || req?.body;
+        const data = req?.body;
         const headers = req.headers;
 
         // Process our callback

--- a/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
@@ -84,10 +84,8 @@ export default class HTTPServerImpl {
 
       // Add a server POST handler
       this.server.post(`/${routeObj.path}`, async (req, res) => {
-        // @ts-ignore
         // Parse the data of the body, we prioritize fetching the data key in body if possible
         // i.e. Redis returns { data: {} } and other services return {}
-        // @todo: This will be deprecated in an upcoming major version and only req.body will be returned
         const data = req?.body;
         const headers = req.headers;
 

--- a/test/e2e/http/server.test.ts
+++ b/test/e2e/http/server.test.ts
@@ -116,6 +116,7 @@ describe("http/server", () => {
       // Also test for receiving data
       // @ts-ignore
       expect(mockBindingReceive.mock.calls[0][0]["hello"]).toEqual("world");
+      expect(mockBindingReceive.mock.calls.length).toBe(1);
     });
   });
 
@@ -235,7 +236,7 @@ describe("http/server", () => {
       expect(res).toEqual(true);
     });
 
-    it("should receive the entire body instead of just data, this also contains the content type, time, traces, ...", async () => {
+    it("should be able to receive the entire cloud event", async () => {
       await server.client.pubsub.publish("pubsub-redis", "topic-options-6", { data: { hello: "world" } });
 
       // Delay a bit for event to arrive


### PR DESCRIPTION
Signed-off-by: Xavier Geerinck <xavier.geerinck@gmail.com>

# Description

We deprecated `req.body.data` in favor of `req.body` on the HTTP Pub Sub component. This means that data will now be in `req.body.data` and users should fetch accordingly.

The advantage of working this way is that providers that don't return data can be parsed and users can as well get the headers around it (e.g., source, pubsubname, datacontenttype, ...)

More practical, instead of returning:

```javascript
{
    hello: "world"
}
```

We will be returning:

```javascript
{
  data: { hello: 'world' },
  datacontenttype: 'application/json',
  id: '80e37aaa-a7e4-4484-a74e-2fd9e0194c47',
  pubsubname: 'pubsub-redis',
  source: 'test-suite',
  specversion: '1.0',
  time: '2022-11-29T11:30:16+01:00',
  topic: 'topic-1',
  traceid: '00-d0a8afe02330296da9046a7d827eecbe-8876a7ac21b31b6f-01',
  traceparent: '00-d0a8afe02330296da9046a7d827eecbe-8876a7ac21b31b6f-01',
  tracestate: '',
  type: 'com.dapr.event.sent'
}
```

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [ ] Extended the documentation
