### PR TITLE
feat(pubsub): Allow setting explicit content-type during publish operations

### DIFF
--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -304,6 +304,7 @@ async function start() {
   const topic = "topic-a";
 
   // Publish message to topic as text/plain
+  // Note, the content type is inferred from the message type unless specified explicitly
   const response = await client.pubsub.publish(pubSubName, topic, "hello, world!");
   // If publish fails, response contains the error
   console.log(response);
@@ -320,6 +321,14 @@ async function start() {
     id: "1234",
   };
   await client.pubsub.publish(pubSubName, topic, cloudEvent);
+
+  // Publish the cloudevent as application/json
+  const options = { contentType: "application/json" };
+  await client.pubsub.publish(pubSubName, topic, cloudEvent, options);
+
+  // Publish the cloudevent as raw payload
+  const options = { metadata: { rawPayload: true } };
+  await client.pubsub.publish(pubSubName, topic, "hello, world!", options);
 
   // Publish multiple messages to a topic as text/plain
   await client.pubsub.publishBulk(pubSubName, topic, ["message 1", "message 2", "message 3"]);

--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -312,6 +312,10 @@ async function start() {
   // Publish message to topic as application/json
   await client.pubsub.publish(pubSubName, topic, { hello: "world" });
 
+  // Publish a JSON message as plain text
+  const options = { contentType: "text/plain" };
+  await client.pubsub.publish(pubSubName, topic, { hello: "world" }, options);
+
   // Publish message to topic as application/cloudevents+json
   // You can also use the cloudevent SDK to create cloud events https://github.com/cloudevents/sdk-javascript
   const cloudEvent = {
@@ -322,11 +326,7 @@ async function start() {
   };
   await client.pubsub.publish(pubSubName, topic, cloudEvent);
 
-  // Publish the cloudevent as application/json
-  const options = { contentType: "application/json" };
-  await client.pubsub.publish(pubSubName, topic, cloudEvent, options);
-
-  // Publish the cloudevent as raw payload
+  // Publish a cloudevent as raw payload
   const options = { metadata: { rawPayload: true } };
   await client.pubsub.publish(pubSubName, topic, "hello, world!", options);
 

--- a/examples/pubsub/package-lock.json
+++ b/examples/pubsub/package-lock.json
@@ -28,14 +28,14 @@
         "@types/google-protobuf": "^3.15.5",
         "@types/node-fetch": "^2.6.2",
         "body-parser": "^1.19.0",
+        "express": "^4.18.2",
         "google-protobuf": "^3.18.0",
         "http-terminator": "^3.0.4",
-        "node-fetch": "^2.6.7",
-        "restana": "^4.9.1",
-        "uuid": "^8.3.2"
+        "node-fetch": "^2.6.7"
       },
       "devDependencies": {
         "@types/body-parser": "^1.19.1",
+        "@types/express": "^4.17.15",
         "@types/jest": "^27.0.1",
         "@types/node": "^16.9.1",
         "@types/uuid": "^8.3.1",
@@ -264,6 +264,7 @@
         "@grpc/grpc-js": "^1.3.7",
         "@js-temporal/polyfill": "^0.3.0",
         "@types/body-parser": "^1.19.1",
+        "@types/express": "^4.17.15",
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^27.0.1",
         "@types/node": "^16.9.1",
@@ -276,6 +277,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-header": "^3.1.1",
         "eslint-plugin-prettier": "^4.2.1",
+        "express": "^4.18.2",
         "google-protobuf": "^3.18.0",
         "grpc_tools_node_protoc_ts": "^5.3.2",
         "http-terminator": "^3.0.4",
@@ -285,10 +287,8 @@
         "nodemon": "^2.0.20",
         "prettier": "^2.4.0",
         "pretty-quick": "^3.1.3",
-        "restana": "^4.9.1",
         "ts-jest": "^27.0.5",
-        "typescript": "^4.5.5",
-        "uuid": "^8.3.2"
+        "typescript": "^4.5.5"
       }
     },
     "@types/node": {

--- a/examples/pubsub/src/index.ts
+++ b/examples/pubsub/src/index.ts
@@ -31,13 +31,13 @@ async function start() {
   });
 
   // Publish multiple messages to a topic with default config.
-  await client.pubsub.subscribeBulk("my-pubsub-component", "my-topic", async (data: Record<string, any>) => {
+  await server.pubsub.subscribeBulk("my-pubsub-component", "my-topic", async (data: Record<string, any>) => {
     // The library parses JSON when possible.
     console.log(`[Dapr-JS][Example] Received on subscription: ${JSON.stringify(data)}`);
   });
 
   // Publish multiple messages to a topic with specific maxMessagesCount and maxAwaitDurationMs.
-  await client.pubsub.subscribeBulk(
+  await server.pubsub.subscribeBulk(
     "my-pubsub-component",
     "my-topic",
     async (data: Record<string, any>) => {

--- a/src/implementation/Client/GRPCClient/pubsub.ts
+++ b/src/implementation/Client/GRPCClient/pubsub.ts
@@ -49,16 +49,9 @@ export default class GRPCClientPubSub implements IClientPubSub {
     msgService.setTopic(topic);
 
     if (data) {
-      const serialized = SerializerUtil.serializeGrpc(data);
+      const serialized = SerializerUtil.serializeGrpc(data, options.contentType);
       msgService.setData(serialized.serializedData);
-
-      // Set content type if provided.
-      // Otherwise, use the one inferred by the serializer.
-      if (options.contentType) {
-        msgService.setDataContentType(options.contentType);
-      } else {
-        msgService.setDataContentType(serialized.contentType);
-      }
+      msgService.setDataContentType(serialized.contentType);
     }
 
     addMetadataToMap(msgService.getMetadataMap(), options.metadata);

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -146,8 +146,6 @@ export default class HTTPClient implements IClient {
     const agent = urlFull.startsWith("https") ? HTTPClient.httpsAgent : HTTPClient.httpAgent;
     clientOptions.agent = agent;
 
-    this.logger.debug("Body content: ", clientOptions.body?.toString?.());
-
     this.logger.debug(
       `Fetching ${clientOptions.method} ${urlFull} with (headers: ${JSON.stringify(
         clientOptions.headers,

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -132,13 +132,11 @@ export default class HTTPClient implements IClient {
 
     // Set Body and Content-Type Header
     if (params?.body) {
-      const { serializedData, contentType } = SerializerUtil.serializeHttp(params?.body);
+      // If content-type is already present, use that to serialize the data.
+      const headerContentType = params?.headers?.["Content-Type"] ?? undefined;
+      const { serializedData, contentType } = SerializerUtil.serializeHttp(params?.body, headerContentType);
 
-      // Don't overwrite it
-      if (!params?.headers?.["Content-Type"]) {
-        clientOptions.headers["Content-Type"] = contentType;
-      }
-
+      clientOptions.headers["Content-Type"] = contentType;
       clientOptions.body = serializedData;
     }
 

--- a/src/implementation/Client/HTTPClient/HTTPClient.ts
+++ b/src/implementation/Client/HTTPClient/HTTPClient.ts
@@ -146,6 +146,8 @@ export default class HTTPClient implements IClient {
     const agent = urlFull.startsWith("https") ? HTTPClient.httpsAgent : HTTPClient.httpAgent;
     clientOptions.agent = agent;
 
+    this.logger.debug("Body content: ", clientOptions.body?.toString?.());
+
     this.logger.debug(
       `Fetching ${clientOptions.method} ${urlFull} with (headers: ${JSON.stringify(
         clientOptions.headers,

--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -81,7 +81,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     };
 
     const entries = getBulkPublishEntries(messages);
-    params.body = JSON.stringify(entries);
+    params.body = entries;
 
     try {
       await this.client.executeWithApiVersion(

--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -25,6 +25,7 @@ import { PubSubBulkPublishResponse } from "../../../types/pubsub/PubSubBulkPubli
 import { PubSubBulkPublishMessage } from "../../../types/pubsub/PubSubBulkPublishMessage.type";
 import { PubSubBulkPublishEntry } from "../../../types/pubsub/PubSubBulkPublishEntry.type";
 import { PubSubPublishResponseType } from "../../../types/pubsub/PubSubPublishResponse.type";
+import { PubSubPublishOptions } from "../../../types/pubsub/PubSubPublishOptions.type";
 
 // https://docs.dapr.io/reference/api/pubsub_api/
 export default class HTTPClientPubSub implements IClientPubSub {
@@ -40,14 +41,22 @@ export default class HTTPClientPubSub implements IClientPubSub {
     pubSubName: string,
     topic: string,
     data: object | string,
-    metadata?: KeyValueType,
+    options: PubSubPublishOptions = {},
   ): Promise<PubSubPublishResponseType> {
-    const queryParams = createHTTPMetadataQueryParam(metadata);
+    const queryParams = createHTTPMetadataQueryParam(options.metadata);
+
+    // Set content type if provided.
+    // If not, HTTPClient will infer it from the data.
+    const headers: KeyValueType = {};
+    if (options.contentType) {
+      headers["Content-Type"] = options.contentType;
+    }
 
     try {
       await this.client.execute(`/publish/${pubSubName}/${topic}?${queryParams}`, {
         method: "POST",
         body: data,
+        headers,
       });
     } catch (e: any) {
       this.logger.error(`publish failed: ${e}`);

--- a/src/interfaces/Client/IClientPubSub.ts
+++ b/src/interfaces/Client/IClientPubSub.ts
@@ -14,6 +14,7 @@ limitations under the License.
 import { KeyValueType } from "../../types/KeyValue.type";
 import { PubSubBulkPublishMessage } from "../../types/pubsub/PubSubBulkPublishMessage.type";
 import { PubSubBulkPublishResponse } from "../../types/pubsub/PubSubBulkPublishResponse.type";
+import { PubSubPublishOptions } from "../../types/pubsub/PubSubPublishOptions.type";
 import { PubSubPublishResponseType } from "../../types/pubsub/PubSubPublishResponse.type";
 
 export default interface IClientPubSub {
@@ -33,7 +34,7 @@ export default interface IClientPubSub {
     pubSubName: string,
     topic: string,
     data?: object | string,
-    metadata?: KeyValueType,
+    options?: PubSubPublishOptions,
   ): Promise<PubSubPublishResponseType>;
 
   /**

--- a/src/types/pubsub/PubSubPublishOptions.type.ts
+++ b/src/types/pubsub/PubSubPublishOptions.type.ts
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { KeyValueType } from "../KeyValue.type";
+
+export type PubSubPublishOptions = {
+  /**
+   * The content type of the message.
+   * This is optional and will be inferred from the payload if not provided.
+   */
+  contentType?: string;
+
+  /**
+   * Metadata to be passed to the publish operation.
+   */
+  metadata?: KeyValueType;
+};

--- a/src/utils/Serializer.util.ts
+++ b/src/utils/Serializer.util.ts
@@ -14,10 +14,17 @@ limitations under the License.
 import { getContentType } from "./Client.util";
 import { BodyInit } from "node-fetch";
 
-export function serializeGrpc(data: any): { serializedData: Buffer; contentType: string } {
+/**
+ * Serialize data for gRPC requests.
+ * If no content type is provided, it will be inferred from the data.
+ * @param data data to serialize
+ * @param inContentType content type of the data
+ * @returns serialized data and content type
+ */
+export function serializeGrpc(data: any, inContentType?: string): { serializedData: Buffer; contentType: string } {
   let serializedData: Buffer = data;
 
-  const contentType = getContentType(data);
+  const contentType = inContentType ?? getContentType(data);
 
   switch (contentType) {
     case "application/json":
@@ -36,14 +43,24 @@ export function serializeGrpc(data: any): { serializedData: Buffer; contentType:
   return { serializedData, contentType };
 }
 
-export function serializeHttp(data: any): {
+/**
+ * Serialize data for HTTP requests.
+ * If no content type is provided, it will be inferred from the data.
+ * @param data data to serialize
+ * @param inContentType content type of the data
+ * @returns serialized data and content type
+ */
+export function serializeHttp(
+  data: any,
+  inContentType?: string,
+): {
   // https://developer.mozilla.org/en-US/docs/Web/API/fetch#body
   serializedData: BodyInit;
   contentType: string;
 } {
   let serializedData: BodyInit;
 
-  const contentType = getContentType(data);
+  const contentType = inContentType ?? getContentType(data);
 
   switch (contentType) {
     case "application/json":

--- a/test/unit/grpc/pubsub.test.ts
+++ b/test/unit/grpc/pubsub.test.ts
@@ -67,19 +67,19 @@ describe("grpc/pubsub", () => {
     it("should use the content-type when provided", async () => {
       const requests: PublishEventRequest[] = [];
       const grpcClientPubsub = new GRPCClientPubSub(getMockClient(requests));
-      await grpcClientPubsub.publish(
-        "my-pubsub",
-        "my-topic",
-        { key: "value" },
-        { contentType: "text/plain", metadata: { mKey: "mValue" } },
-      );
+
+      const inData = { key: "value" };
+      await grpcClientPubsub.publish("my-pubsub", "my-topic", inData, {
+        contentType: "text/plain",
+        metadata: { mKey: "mValue" },
+      });
 
       // Check the request
       expect(requests.length).toBe(1);
       const pubsub = requests[0];
       expect(pubsub.getPubsubName()).toBe("my-pubsub");
       expect(pubsub.getTopic()).toBe("my-topic");
-      expect(pubsub.getData()).toStrictEqual(Buffer.from(JSON.stringify({ key: "value" })));
+      expect(pubsub.getData()).toStrictEqual(Buffer.from(inData.toString()));
       expect(pubsub.getDataContentType()).toBe("text/plain");
       expect(pubsub.getMetadataMap().getLength()).toBe(1);
       expect(pubsub.getMetadataMap().get("mKey")).toBe("mValue");

--- a/test/unit/grpc/pubsub.test.ts
+++ b/test/unit/grpc/pubsub.test.ts
@@ -35,7 +35,7 @@ describe("grpc/pubsub", () => {
     it("should create the correct pubsub request", async () => {
       const requests: PublishEventRequest[] = [];
       const grpcClientPubsub = new GRPCClientPubSub(getMockClient(requests));
-      await grpcClientPubsub.publish("my-pubsub", "my-topic", { key: "value" }, { mKey: "mValue" });
+      await grpcClientPubsub.publish("my-pubsub", "my-topic", { key: "value" }, { metadata: { mKey: "mValue" } });
 
       // Check the request
       expect(requests.length).toBe(1);
@@ -51,7 +51,7 @@ describe("grpc/pubsub", () => {
     it("should skip data and content-type when data is not present", async () => {
       const requests: PublishEventRequest[] = [];
       const grpcClientPubsub = new GRPCClientPubSub(getMockClient(requests));
-      await grpcClientPubsub.publish("my-pubsub", "my-topic", "", { mKey: "mValue" });
+      await grpcClientPubsub.publish("my-pubsub", "my-topic", "", { metadata: { mKey: "mValue" } });
 
       // Check the request
       expect(requests.length).toBe(1);
@@ -60,6 +60,22 @@ describe("grpc/pubsub", () => {
       expect(pubsub.getTopic()).toBe("my-topic");
       expect(pubsub.getData()).toStrictEqual("");
       expect(pubsub.getDataContentType()).toBe("");
+      expect(pubsub.getMetadataMap().getLength()).toBe(1);
+      expect(pubsub.getMetadataMap().get("mKey")).toBe("mValue");
+    });
+
+    it("should use the content-type when provided", async () => {
+      const requests: PublishEventRequest[] = [];
+      const grpcClientPubsub = new GRPCClientPubSub(getMockClient(requests));
+      await grpcClientPubsub.publish("my-pubsub", "my-topic", { key: "value" }, { contentType: "text/plain", metadata: { mKey: "mValue" } });
+
+      // Check the request
+      expect(requests.length).toBe(1);
+      const pubsub = requests[0];
+      expect(pubsub.getPubsubName()).toBe("my-pubsub");
+      expect(pubsub.getTopic()).toBe("my-topic");
+      expect(pubsub.getData()).toStrictEqual(Buffer.from(JSON.stringify({ key: "value" })));
+      expect(pubsub.getDataContentType()).toBe("text/plain");
       expect(pubsub.getMetadataMap().getLength()).toBe(1);
       expect(pubsub.getMetadataMap().get("mKey")).toBe("mValue");
     });

--- a/test/unit/grpc/pubsub.test.ts
+++ b/test/unit/grpc/pubsub.test.ts
@@ -67,7 +67,12 @@ describe("grpc/pubsub", () => {
     it("should use the content-type when provided", async () => {
       const requests: PublishEventRequest[] = [];
       const grpcClientPubsub = new GRPCClientPubSub(getMockClient(requests));
-      await grpcClientPubsub.publish("my-pubsub", "my-topic", { key: "value" }, { contentType: "text/plain", metadata: { mKey: "mValue" } });
+      await grpcClientPubsub.publish(
+        "my-pubsub",
+        "my-topic",
+        { key: "value" },
+        { contentType: "text/plain", metadata: { mKey: "mValue" } },
+      );
 
       // Check the request
       expect(requests.length).toBe(1);

--- a/test/unit/utils/Serializer.util.test.ts
+++ b/test/unit/utils/Serializer.util.test.ts
@@ -79,4 +79,11 @@ describe("serializer", () => {
 
     expect(payloadLength).toEqual(dataLength);
   });
+
+  runIt("should serialize an Object as text/plain if specified", () => {
+    const data = { Hello: "World" };
+    const { serializedData, contentType } = SerializerUtil.serializeGrpc(data, "text/plain");
+    expect(Buffer.compare(serializedData, Buffer.from(data.toString()))).toEqual(0);
+    expect(contentType).toEqual("text/plain");
+  });
 });


### PR DESCRIPTION
# Description

This PR 
- introduces an options parameter to Publish in DaprClient
- adds an option to serializer to override the content-type (and not always infer it)


## Issue reference

Please reference the issue this PR will close: #442

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
