### PR TITLE
Fix/query

### DIFF
--- a/src/implementation/Client/GRPCClient/state.ts
+++ b/src/implementation/Client/GRPCClient/state.ts
@@ -253,7 +253,7 @@ export default class GRPCClientState implements IClientState {
           return resolve({
             results: [],
             token: res.getToken(),
-          });
+          } as StateQueryResponseType);
         }
 
         // https://docs.dapr.io/reference/api/state_api/#response-body

--- a/src/implementation/Client/GRPCClient/state.ts
+++ b/src/implementation/Client/GRPCClient/state.ts
@@ -248,6 +248,13 @@ export default class GRPCClientState implements IClientState {
         if (err) {
           return reject(err);
         }
+        const resultsList = res.getResultsList();
+        if (resultsList.length === 0) {
+          return resolve({
+            results: [],
+            token: res.getToken(),
+          });
+        }
 
         // https://docs.dapr.io/reference/api/state_api/#response-body
         // map the res from gRPC

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -104,7 +104,7 @@ export default class HTTPClientState implements IClientState {
     });
 
     if (result === "") {
-      return [];
+      return { results: [] };
     }
 
     return result as StateQueryResponseType;

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -103,6 +103,10 @@ export default class HTTPClientState implements IClientState {
       },
     });
 
+    if (result === "") {
+      return [];
+    }
+
     return result as StateQueryResponseType;
   }
 }

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -104,7 +104,7 @@ export default class HTTPClientState implements IClientState {
     });
 
     if (result === "") {
-      return { results: [] };
+      return { results: [] } as StateQueryResponseType;
     }
 
     return result as StateQueryResponseType;

--- a/test/e2e/common/client.test.ts
+++ b/test/e2e/common/client.test.ts
@@ -464,5 +464,23 @@ describe("common/client", () => {
         await httpClient.state.delete(stateStoreMongoDbName, `key-${i}`);
       }
     });
+
+    it("should return an empty object when result is empty", async () => {
+      const result = await httpClient.state.query(stateStoreMongoDbName, {
+        filter: { EQ: { state: "statenotfound" } }, sort: [
+          {
+            key: "state",
+            order: "DESC",
+          },
+        ],
+        page: {
+          limit: 10,
+        },
+      });
+      expect(result).toEqual({ results: [] });
+    });
+
+
+
   });
 });

--- a/test/e2e/common/client.test.ts
+++ b/test/e2e/common/client.test.ts
@@ -467,7 +467,8 @@ describe("common/client", () => {
 
     it("should return an empty object when result is empty", async () => {
       const result = await httpClient.state.query(stateStoreMongoDbName, {
-        filter: { EQ: { state: "statenotfound" } }, sort: [
+        filter: { EQ: { state: "statenotfound" } },
+        sort: [
           {
             key: "state",
             order: "DESC",
@@ -479,8 +480,5 @@ describe("common/client", () => {
       });
       expect(result).toEqual({ results: [] });
     });
-
-
-
   });
 });


### PR DESCRIPTION
# Description

This PR adds a fix for an issue where the state query method returns an empty string instead of a `StateQueryResponseType` when there are no results to return. The fix adds an `if` statement to handle empty responses and return an empty array instead.

## Issue reference

This PR closes #460.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
