### PR TITLE
Adding optional attributes in state management API

### DIFF
--- a/src/enum/StateConcurrency.enum.ts
+++ b/src/enum/StateConcurrency.enum.ts
@@ -17,4 +17,4 @@ export enum StateConcurrencyEnum {
   CONCURRENCY_LAST_WRITE = 2,
 }
 
-export default StateConcurrencyEnum
+export default StateConcurrencyEnum;

--- a/src/enum/StateConcurrency.enum.ts
+++ b/src/enum/StateConcurrency.enum.ts
@@ -11,8 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export enum EStateConcurrency {
+export enum StateConcurrencyEnum {
   CONCURRENCY_UNSPECIFIED = 0,
   CONCURRENCY_FIRST_WRITE = 1,
   CONCURRENCY_LAST_WRITE = 2,
 }
+
+export default StateConcurrencyEnum

--- a/src/enum/StateConsistency.enum.ts
+++ b/src/enum/StateConsistency.enum.ts
@@ -11,8 +11,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export enum EStateConsistency {
+export enum StateConsistencyEnum {
   CONSISTENCY_UNSPECIFIED = 0,
   CONSISTENCY_EVENTUAL = 1,
   CONSISTENCY_STRONG = 2,
 }
+export default StateConsistencyEnum;

--- a/src/implementation/Client/GRPCClient/state.ts
+++ b/src/implementation/Client/GRPCClient/state.ts
@@ -291,11 +291,11 @@ export default class GRPCClientState implements IClientState {
 
     const stateOptions = new StateOptions();
     if (opt?.consistency) {
-      stateOptions.setConsistency(opt.consistency);
+      stateOptions.setConsistency(opt.consistency as any);
     }
 
     if (opt?.concurrency) {
-      stateOptions.setConcurrency(opt.concurrency);
+      stateOptions.setConcurrency(opt.concurrency as any);
     }
 
     return stateOptions;

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -64,10 +64,11 @@ export default class HTTPClientState implements IClientState {
 
     // Manage non-metadata query parameters
     const optParams = createHTTPStateBehavioralQueryParam(options);
-
     let queryParams = `${metadataParams}${optParams}`;
     // If metadataParam is empty
-    if (queryParams.startsWith("&")) queryParams = queryParams.substring(1);
+    if (queryParams.startsWith("&")) {
+      queryParams = queryParams.substring(1);
+    }
 
     const result = await this.client.execute(`/state/${storeName}/${key}`);
 
@@ -93,14 +94,17 @@ export default class HTTPClientState implements IClientState {
 
     // Managed headers
     const headers: THTTPExecuteParams["headers"] = {};
-    if (options?.etag) headers["If-Match"] = options.etag;
+    if (options?.etag) {
+      headers["If-Match"] = options.etag;
+    }
 
     // Manage non-metadata query parameters
     const optParams = createHTTPStateBehavioralQueryParam(options);
-
     let queryParams = `${metadataParams}${optParams}`;
     // If metadataParam is empty
-    if (queryParams.startsWith("&")) queryParams = queryParams.substring(1);
+    if (queryParams.startsWith("&")) {
+      queryParams = queryParams.substring(1);
+    }
 
     try {
       await this.client.execute(`/state/${storeName}/${key}?${queryParams}`, {
@@ -111,6 +115,7 @@ export default class HTTPClientState implements IClientState {
       this.logger.error(`Error deleting state from store ${storeName}, error: ${e}`);
       return { error: e };
     }
+
     return {};
   }
 

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -64,7 +64,9 @@ export default class HTTPClientState implements IClientState {
 
     // Manage non-metadata query parameters
     const optParams = createHTTPStateBehavioralQueryParam(options);
+
     let queryParams = `${metadataParams}${optParams}`;
+
     // If metadataParam is empty
     if (queryParams.startsWith("&")) {
       queryParams = queryParams.substring(1);
@@ -100,7 +102,9 @@ export default class HTTPClientState implements IClientState {
 
     // Manage non-metadata query parameters
     const optParams = createHTTPStateBehavioralQueryParam(options);
+
     let queryParams = `${metadataParams}${optParams}`;
+
     // If metadataParam is empty
     if (queryParams.startsWith("&")) {
       queryParams = queryParams.substring(1);

--- a/src/implementation/Client/HTTPClient/state.ts
+++ b/src/implementation/Client/HTTPClient/state.ts
@@ -70,7 +70,7 @@ export default class HTTPClientState implements IClientState {
       queryParams = queryParams.substring(1);
     }
 
-    const result = await this.client.execute(`/state/${storeName}/${key}`);
+    const result = await this.client.execute(`/state/${storeName}/${key}?${queryParams}`);
 
     return result as KeyValueType;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,8 @@ import { PubSubBulkPublishMessage } from "./types/pubsub/PubSubBulkPublishMessag
 import HttpMethod from "./enum/HttpMethod.enum";
 import CommunicationProtocolEnum from "./enum/CommunicationProtocol.enum";
 import DaprPubSubStatusEnum from "./enum/DaprPubSubStatus.enum";
+import StateConcurrencyEnum from "./enum/StateConcurrency.enum";
+import StateConsistencyEnum from "./enum/StateConsistency.enum";
 import { StateGetBulkOptions } from "./types/state/StateGetBulkOptions.type";
 
 export {
@@ -59,6 +61,8 @@ export {
   CommunicationProtocolEnum,
   DaprPubSubStatusEnum,
   PubSubBulkPublishMessage,
+  StateConcurrencyEnum,
+  StateConsistencyEnum,
   PubSubBulkPublishResponse,
   StateGetBulkOptions,
 };

--- a/src/interfaces/Client/IClientState.ts
+++ b/src/interfaces/Client/IClientState.ts
@@ -20,12 +20,14 @@ import { StateQueryResponseType } from "../../types/state/StateQueryResponse.typ
 import { StateGetBulkOptions } from "../../types/state/StateGetBulkOptions.type";
 import { StateSaveResponseType } from "../../types/state/StateSaveResponseType";
 import { StateSaveOptions } from "../../types/state/StateSaveOptions.type";
+import { StateDeleteOptions } from "../../types/state/StateDeleteOptions.type";
+import { StateGetOptions } from "../../types/state/StateGetOptions.type";
 
 export default interface IClientState {
   save(storeName: string, stateObjects: KeyValuePairType[], options?: StateSaveOptions): Promise<StateSaveResponseType>;
-  get(storeName: string, key: string): Promise<KeyValueType | string>;
+  get(storeName: string, key: string, options?: Partial<StateGetOptions>): Promise<KeyValueType | string>;
   getBulk(storeName: string, keys: string[], options?: StateGetBulkOptions): Promise<KeyValueType[]>;
-  delete(storeName: string, key: string): Promise<void>;
+  delete(storeName: string, key: string, options?: Partial<StateDeleteOptions>): Promise<StateSaveResponseType>;
   transaction(storeName: string, operations?: OperationType[], metadata?: IRequestMetadata | null): Promise<void>;
   query(storeName: string, query: StateQueryType): Promise<StateQueryResponseType>;
 }

--- a/src/types/state/StateDeleteOptions.type.ts
+++ b/src/types/state/StateDeleteOptions.type.ts
@@ -20,6 +20,7 @@ export type StateDeleteOptions = IStateOptions & {
    * Metadata to be passed to the operation.
    */
   metadata: IRequestMetadata;
+
   /**
    * Optional Etag for Optimistic Concurrency Control
    */

--- a/src/types/state/StateDeleteOptions.type.ts
+++ b/src/types/state/StateDeleteOptions.type.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Dapr Authors
+Copyright 2023 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,13 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { KeyValueType } from "./KeyValue.type";
-import { IStateOptions } from "./state/StateOptions.type";
+import { IRequestMetadata } from "../RequestMetadata.type";
+import { IStateOptions } from "./StateOptions.type";
+import { KeyValuePairType } from "../KeyValuePair.type";
 
-export type KeyValuePairType = {
-  key: string;
-  value: any;
-  etag?: string;
-  metadata?: KeyValueType;
-  options?: IStateOptions;
+export type StateDeleteOptions = IStateOptions & {
+  /**
+   * Metadata to be passed to the operation.
+   */
+  metadata: IRequestMetadata;
+  /**
+   * Optional Etag for Optimistic Concurrency Control
+   */
+  etag: KeyValuePairType["etag"];
 };

--- a/src/types/state/StateGetOptions.type.ts
+++ b/src/types/state/StateGetOptions.type.ts
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 The Dapr Authors
+Copyright 2023 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -11,13 +11,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { KeyValueType } from "./KeyValue.type";
-import { IStateOptions } from "./state/StateOptions.type";
+import { IRequestMetadata } from "../RequestMetadata.type";
+import { IStateOptions } from "./StateOptions.type";
 
-export type KeyValuePairType = {
-  key: string;
-  value: any;
-  etag?: string;
-  metadata?: KeyValueType;
-  options?: IStateOptions;
+export type StateGetOptions = Pick<IStateOptions, "consistency"> & {
+  /**
+   * Metadata to be passed to the operation.
+   */
+  metadata: IRequestMetadata;
 };

--- a/src/types/state/StateOptions.type.ts
+++ b/src/types/state/StateOptions.type.ts
@@ -11,10 +11,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { EStateConsistency } from "../../enum/StateConsistency.enum";
-import { EStateConcurrency } from "../../enum/StateConcurrency.enum";
+import { StateConsistencyEnum } from "../../enum/StateConsistency.enum";
+import { StateConcurrencyEnum } from "../../enum/StateConcurrency.enum";
 
 export type IStateOptions = {
-  concurrency: EStateConcurrency;
-  consistency: EStateConsistency;
+  concurrency: StateConcurrencyEnum;
+  consistency: StateConsistencyEnum;
 };

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -75,12 +75,12 @@ export function createHTTPStateBehavioralQueryParam(params: Partial<IStateOption
   const optParamsBuilder = new URLSearchParams();
 
   if (params?.consistency) {
-    const consistency = matchStateConsistency(params?.consistency);
+    const consistency = getStateConsistencyValue(params?.consistency);
     if (consistency !== undefined) optParamsBuilder.set("consistency", consistency);
   }
 
   if (params?.concurrency) {
-    const concurrency = matchStateConcurrency(params?.concurrency);
+    const concurrency = getStateConcurrencyValue(params?.concurrency);
     if (concurrency !== undefined) optParamsBuilder.set("concurrency", concurrency);
   }
 
@@ -91,7 +91,7 @@ export function createHTTPStateBehavioralQueryParam(params: Partial<IStateOption
  * Return the string representation of a valid consistency configuration
  * @param c
  */
-export function matchStateConsistency(c: EStateConsistency): "eventual" | "strong" | undefined {
+export function getStateConsistencyValue(c: EStateConsistency): "eventual" | "strong" | undefined {
   switch (c) {
     case EStateConsistency.CONSISTENCY_EVENTUAL:
       return "eventual";
@@ -106,7 +106,7 @@ export function matchStateConsistency(c: EStateConsistency): "eventual" | "stron
  * Return the string representation of a valid concurrency configuration
  * @param c
  */
-export function matchStateConcurrency(c: EStateConcurrency): "first-write" | "last-write" | undefined {
+export function getStateConcurrencyValue(c: EStateConcurrency): "first-write" | "last-write" | undefined {
   switch (c) {
     case EStateConcurrency.CONCURRENCY_FIRST_WRITE:
       return "first-write";

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -76,12 +76,16 @@ export function createHTTPStateBehavioralQueryParam(params: Partial<IStateOption
 
   if (params?.consistency) {
     const consistency = getStateConsistencyValue(params?.consistency);
-    if (consistency !== undefined) optParamsBuilder.set("consistency", consistency);
+    if (consistency !== undefined) {
+      optParamsBuilder.set("consistency", consistency);
+    }
   }
 
   if (params?.concurrency) {
     const concurrency = getStateConcurrencyValue(params?.concurrency);
-    if (concurrency !== undefined) optParamsBuilder.set("concurrency", concurrency);
+    if (concurrency !== undefined) {
+      optParamsBuilder.set("concurrency", concurrency);
+    }
   }
 
   return optParamsBuilder.toString();

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -31,8 +31,6 @@ import { LoggerOptions } from "../types/logger/LoggerOptions";
 import { StateConsistencyEnum } from "../enum/StateConsistency.enum";
 import { StateConcurrencyEnum } from "../enum/StateConcurrency.enum";
 import { URLSearchParams } from "url";
-import { IStateOptions } from "../types/state/StateOptions.type";
-
 /**
  * Adds metadata to a map.
  * @param map Input map

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -28,8 +28,8 @@ import { DaprClientOptions } from "../types/DaprClientOptions";
 import CommunicationProtocolEnum from "../enum/CommunicationProtocol.enum";
 import { Settings } from "./Settings.util";
 import { LoggerOptions } from "../types/logger/LoggerOptions";
-import { EStateConsistency } from "../enum/StateConsistency.enum";
-import { EStateConcurrency } from "../enum/StateConcurrency.enum";
+import { StateConsistencyEnum } from "../enum/StateConsistency.enum";
+import { StateConcurrencyEnum } from "../enum/StateConcurrency.enum";
 import { URLSearchParams } from "url";
 import { IStateOptions } from "../types/state/StateOptions.type";
 
@@ -91,11 +91,11 @@ export function createHTTPStateBehavioralQueryParam(params: Partial<IStateOption
  * Return the string representation of a valid consistency configuration
  * @param c
  */
-export function getStateConsistencyValue(c: EStateConsistency): "eventual" | "strong" | undefined {
+export function getStateConsistencyValue(c: StateConsistencyEnum): "eventual" | "strong" | undefined {
   switch (c) {
-    case EStateConsistency.CONSISTENCY_EVENTUAL:
+    case StateConsistencyEnum.CONSISTENCY_EVENTUAL:
       return "eventual";
-    case EStateConsistency.CONSISTENCY_STRONG:
+    case StateConsistencyEnum.CONSISTENCY_STRONG:
       return "strong";
     default:
       return undefined;
@@ -106,11 +106,11 @@ export function getStateConsistencyValue(c: EStateConsistency): "eventual" | "st
  * Return the string representation of a valid concurrency configuration
  * @param c
  */
-export function getStateConcurrencyValue(c: EStateConcurrency): "first-write" | "last-write" | undefined {
+export function getStateConcurrencyValue(c: StateConcurrencyEnum): "first-write" | "last-write" | undefined {
   switch (c) {
-    case EStateConcurrency.CONCURRENCY_FIRST_WRITE:
+    case StateConcurrencyEnum.CONCURRENCY_FIRST_WRITE:
       return "first-write";
-    case EStateConcurrency.CONCURRENCY_LAST_WRITE:
+    case StateConcurrencyEnum.CONCURRENCY_LAST_WRITE:
       return "last-write";
     default:
       return undefined;

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -28,6 +28,10 @@ import { DaprClientOptions } from "../types/DaprClientOptions";
 import CommunicationProtocolEnum from "../enum/CommunicationProtocol.enum";
 import { Settings } from "./Settings.util";
 import { LoggerOptions } from "../types/logger/LoggerOptions";
+import { EStateConsistency } from "../enum/StateConsistency.enum";
+import { EStateConcurrency } from "../enum/StateConcurrency.enum";
+import { URLSearchParams } from "url";
+import { IStateOptions } from "../types/state/StateOptions.type";
 
 /**
  * Adds metadata to a map.
@@ -61,6 +65,56 @@ export function createHTTPMetadataQueryParam(metadata: KeyValueType = {}): strin
   // strip the first "&" if it exists
   queryParam = queryParam.substring(1);
   return queryParam;
+}
+
+/**
+ * Converts a set of optional parameters into a query string
+ * @param params
+ */
+export function createHTTPStateBehavioralQueryParam(params: Partial<IStateOptions> = {}): string {
+  const optParamsBuilder = new URLSearchParams();
+
+  if (params?.consistency) {
+    const consistency = matchStateConsistency(params?.consistency);
+    if (consistency !== undefined) optParamsBuilder.set("consistency", consistency);
+  }
+
+  if (params?.concurrency) {
+    const concurrency = matchStateConcurrency(params?.concurrency);
+    if (concurrency !== undefined) optParamsBuilder.set("concurrency", concurrency);
+  }
+
+  return optParamsBuilder.toString();
+}
+
+/**
+ * Return the string representation of a valid consistency configuration
+ * @param c
+ */
+export function matchStateConsistency(c: EStateConsistency): "eventual" | "strong" | undefined {
+  switch (c) {
+    case EStateConsistency.CONSISTENCY_EVENTUAL:
+      return "eventual";
+    case EStateConsistency.CONSISTENCY_STRONG:
+      return "strong";
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Return the string representation of a valid concurrency configuration
+ * @param c
+ */
+export function matchStateConcurrency(c: EStateConcurrency): "first-write" | "last-write" | undefined {
+  switch (c) {
+    case EStateConcurrency.CONCURRENCY_FIRST_WRITE:
+      return "first-write";
+    case EStateConcurrency.CONCURRENCY_LAST_WRITE:
+      return "last-write";
+    default:
+      return undefined;
+  }
 }
 
 /**

--- a/test/e2e/common/client.test.ts
+++ b/test/e2e/common/client.test.ts
@@ -11,8 +11,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { CommunicationProtocolEnum, DaprClient, LogLevel } from "../../../src";
-import { expect, describe, it } from "@jest/globals";
+import {
+  CommunicationProtocolEnum,
+  DaprClient,
+  LogLevel,
+  StateConcurrencyEnum,
+  StateConsistencyEnum,
+} from "../../../src";
+import { describe, expect, it } from "@jest/globals";
 import { sleep } from "../../../src/utils/NodeJS.util";
 
 const daprHost = "127.0.0.1";
@@ -184,8 +190,8 @@ describe("common/client", () => {
           value: "value-1",
           etag: "1234",
           options: {
-            concurrency: "first-write",
-            consistency: "strong",
+            concurrency: StateConcurrencyEnum.CONCURRENCY_FIRST_WRITE,
+            consistency: StateConsistencyEnum.CONSISTENCY_STRONG,
           },
           metadata: {
             hello: "world",

--- a/test/unit/utils/Client.util.test.ts
+++ b/test/unit/utils/Client.util.test.ts
@@ -20,6 +20,7 @@ import {
   getBulkPublishEntries,
   getBulkPublishResponse,
   getClientOptions,
+  createHTTPQueryParam,
 } from "../../../src/utils/Client.util";
 import { Map } from "google-protobuf";
 import { PubSubBulkPublishEntry } from "../../../src/types/pubsub/PubSubBulkPublishEntry.type";
@@ -89,6 +90,62 @@ describe("Client.util", () => {
       const queryParam = createHTTPMetadataQueryParam(metadata);
       expect(queryParam).toEqual(
         "metadata.key%26with%3Dspecial!ch%23r%23cters=value1%26value2&metadata.key00=value3%20value4",
+      );
+    });
+  });
+
+  describe("createHTTPQueryParam", () => {
+    it("converts a KeyValueType to a HTTP query parameters", () => {
+      const metadata = {
+        key1: "value1",
+        key2: "value2",
+      };
+      const queryParam = createHTTPQueryParam({ data: metadata, type: "metadata" });
+      expect(queryParam).toEqual("metadata.key1=value1&metadata.key2=value2");
+    });
+
+    it("converts a KeyValueType to a HTTP query parameters with empty metadata", () => {
+      const metadata = {};
+      const queryParam = createHTTPQueryParam({ data: metadata, type: "metadata" });
+      expect(queryParam).toEqual("");
+    });
+
+    it("converts a KeyValueType to a HTTP query parameters with no metadata", () => {
+      const queryParam = createHTTPQueryParam();
+      expect(queryParam).toEqual("");
+    });
+
+    it("encodes the query parameters", () => {
+      const metadata = {
+        "key&with=special!ch#r#cters": "value1&value2",
+        key00: "value3 value4",
+      };
+      const queryParam = createHTTPQueryParam({ data: metadata, type: "metadata" });
+      expect(queryParam).toEqual(
+        "metadata.key%26with%3Dspecial%21ch%23r%23cters=value1%26value2&metadata.key00=value3+value4",
+      );
+    });
+
+    it("supports setting non-metadata query parameters", () => {
+      const data = {
+        key1: "value1",
+        key2: "value2",
+      };
+      const queryParam = createHTTPQueryParam({ data });
+      expect(queryParam).toEqual("key1=value1&key2=value2");
+    });
+    it("mix of data and metadata", () => {
+      const data = {
+        key1: "value1",
+        key2: "value2",
+      };
+      const metadata = {
+        "key&with=special!ch#r#cters": "value1&value2",
+        key00: "value3 value4",
+      };
+      const queryParam = createHTTPQueryParam({ data: metadata, type: "metadata" }, { data });
+      expect(queryParam).toEqual(
+        "metadata.key%26with%3Dspecial%21ch%23r%23cters=value1%26value2&metadata.key00=value3+value4&key1=value1&key2=value2",
       );
     });
   });


### PR DESCRIPTION
# Description
This PR adds support for the concurrency and consistency attributes, and adds etag headers where they were missing. 
However, there is still one thing that remains to be done. The [documentation example](https://docs.dapr.io/reference/api/state_api/#example-working-with-etags) about Etags specifies that get request should return the etag value.  The [get request](https://github.com/dapr/js-sdk/blob/main/src/implementation/Client/HTTPClient/state.ts#L59) currently returns a plain string and the etag is even ignored in the HTTP client [execute method](https://github.com/dapr/js-sdk/blob/main/src/implementation/Client/HTTPClient/HTTPClient.ts#L118).
 
I didn't make any changes there, as it would be quite a big breaking change. 
How should we go forward with this ?

## Issue reference

Please reference the issue this PR will close: #475

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [NA] Created/updated tests
- [NA] Extended the documentation
