### PR TITLE
chore(http): Replacing method "createHTTPMetadataQueryParam"

### DIFF
--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -15,11 +15,7 @@ import HTTPClient from "./HTTPClient";
 import IClientPubSub from "../../../interfaces/Client/IClientPubSub";
 import { Logger } from "../../../logger/Logger";
 import { KeyValueType } from "../../../types/KeyValue.type";
-import {
-  createHTTPMetadataQueryParam,
-  getBulkPublishEntries,
-  getBulkPublishResponse,
-} from "../../../utils/Client.util";
+import { createHTTPQueryParam, getBulkPublishEntries, getBulkPublishResponse } from "../../../utils/Client.util";
 import { THTTPExecuteParams } from "../../../types/http/THTTPExecuteParams.type";
 import { PubSubBulkPublishResponse } from "../../../types/pubsub/PubSubBulkPublishResponse.type";
 import { PubSubBulkPublishMessage } from "../../../types/pubsub/PubSubBulkPublishMessage.type";
@@ -43,7 +39,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     data: object | string,
     options: PubSubPublishOptions = {},
   ): Promise<PubSubPublishResponseType> {
-    const queryParams = createHTTPMetadataQueryParam(options.metadata);
+    const queryParams = createHTTPQueryParam({ data: options.metadata, type: "metadata" });
 
     // Set content type if provided.
     // If not, HTTPClient will infer it from the data.
@@ -72,7 +68,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     messages: PubSubBulkPublishMessage[],
     metadata?: KeyValueType | undefined,
   ): Promise<PubSubBulkPublishResponse> {
-    const queryParams = createHTTPMetadataQueryParam(metadata);
+    const queryParams = createHTTPQueryParam({ data: metadata, type: "metadata" });
     const params: THTTPExecuteParams = {
       method: "POST",
       headers: {

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -43,29 +43,6 @@ export function addMetadataToMap(map: Map<string, string>, metadata: KeyValueTyp
 }
 
 /**
- * Converts a KeyValueType to a HTTP query parameters.
- * The query parameters are separated by "&", and the key value pair is separated by "=".
- * Each metadata key is prefixed with "metadata.".
- *
- * Example, if the metadata is { "key1": "value1", "key2": "value2" }, the query parameter will be:
- * "metadata.key1=value1&metadata.key2=value2"
- *
- * Note, the returned value does not contain the "?" prefix.
- *
- * @param metadata key value pair of metadata
- * @returns HTTP query parameter string
- */
-export function createHTTPMetadataQueryParam(metadata: KeyValueType = {}): string {
-  let queryParam = "";
-  for (const [key, value] of Object.entries(metadata)) {
-    queryParam += "&" + "metadata." + encodeURIComponent(key) + "=" + encodeURIComponent(value);
-  }
-  // strip the first "&" if it exists
-  queryParam = queryParam.substring(1);
-  return queryParam;
-}
-
-/**
  * Converts one or multiple sets of data to a querystring
  * Each set of data contains a set of KeyValue Pair
  * An optional "metadata" type can be added in each set, in which case

--- a/test/unit/utils/Client.util.test.ts
+++ b/test/unit/utils/Client.util.test.ts
@@ -14,7 +14,6 @@ limitations under the License.
 import { ConfigurationItem } from "../../../src/proto/dapr/proto/common/v1/common_pb";
 import {
   addMetadataToMap,
-  createHTTPMetadataQueryParam,
   createConfigurationType,
   getContentType,
   getBulkPublishEntries,
@@ -55,45 +54,6 @@ describe("Client.util", () => {
       expect(m.entries()).toEqual(new Map<string, string>([]).entries());
     });
   });
-
-  describe("createHTTPMetadataQueryParam", () => {
-    it("converts a KeyValueType to a HTTP query parameters", () => {
-      const metadata = {
-        key1: "value1",
-        key2: "value2",
-      };
-      const queryParam = createHTTPMetadataQueryParam(metadata);
-      expect(queryParam).toEqual("metadata.key1=value1&metadata.key2=value2");
-    });
-
-    it("converts a KeyValueType to a HTTP query parameters with empty metadata", () => {
-      const metadata = {};
-      const queryParam = createHTTPMetadataQueryParam(metadata);
-      expect(queryParam).toEqual("");
-    });
-
-    it("converts a KeyValueType to a HTTP query parameters with no metadata", () => {
-      const queryParam = createHTTPMetadataQueryParam();
-      expect(queryParam).toEqual("");
-    });
-
-    it("converts a KeyValueType to a HTTP query parameters with undefined metadata", () => {
-      const queryParam = createHTTPMetadataQueryParam(undefined);
-      expect(queryParam).toEqual("");
-    });
-
-    it("encodes the query parameters", () => {
-      const metadata = {
-        "key&with=special!ch#r#cters": "value1&value2",
-        key00: "value3 value4",
-      };
-      const queryParam = createHTTPMetadataQueryParam(metadata);
-      expect(queryParam).toEqual(
-        "metadata.key%26with%3Dspecial!ch%23r%23cters=value1%26value2&metadata.key00=value3%20value4",
-      );
-    });
-  });
-
   describe("createHTTPQueryParam", () => {
     it("converts a KeyValueType to a HTTP query parameters", () => {
       const metadata = {


### PR DESCRIPTION
# Description

Replacing the method "createHTTPMetadataQueryParam" with the newer "createHTTPQueryParam"

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #479

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [NA] Created/updated tests
- [NA] Extended the documentation
