### PR TITLE
fix(actor): Configured the delete operation in the state provider

### DIFF
--- a/src/actors/runtime/StateProvider.ts
+++ b/src/actors/runtime/StateProvider.ts
@@ -76,7 +76,7 @@ export default class StateProvider {
           operation = "upsert";
           break;
         case StateChangeKind.REMOVE:
-          operation = "remove";
+          operation = "delete";
           break;
         case StateChangeKind.UPDATE:
           // dapr doesn't know add, we use upsert

--- a/test/actor/DemoActorDeleteStateImpl.ts
+++ b/test/actor/DemoActorDeleteStateImpl.ts
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { AbstractActor } from "../../src";
+import DemoActorDeleteStateInterface from "./DemoActorDeleteStateInterface";
+
+export default class DemoActorDeleteStateImpl extends AbstractActor implements DemoActorDeleteStateInterface {
+  async init(): Promise<string> {
+    await this.getStateManager().getOrAddState("data", "Hello World!");
+
+    return "state initialized";
+  }
+
+  async getState<T>(): Promise<T | null> {
+    return await this.getStateManager<T>().getState("data");
+  }
+
+  async deleteState(key: string): Promise<void> {
+    await this.getStateManager().removeState(key);
+    await this.getStateManager().saveState();
+  }
+}

--- a/test/actor/DemoActorDeleteStateImpl.ts
+++ b/test/actor/DemoActorDeleteStateImpl.ts
@@ -21,8 +21,9 @@ export default class DemoActorDeleteStateImpl extends AbstractActor implements D
     return "state initialized";
   }
 
-  async getState<T>(): Promise<T | null> {
-    return await this.getStateManager<T>().getState("data");
+  async tryGetState(): Promise<boolean | null> {
+    const [hasValue, _] = await this.getStateManager().tryGetState("data");
+    return hasValue;
   }
 
   async deleteState(key: string): Promise<void> {

--- a/test/actor/DemoActorDeleteStateInterface.ts
+++ b/test/actor/DemoActorDeleteStateInterface.ts
@@ -1,0 +1,18 @@
+/*
+Copyright 2022 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export default interface DemoActorCounterInterface {
+  init(): Promise<string>;
+  getState<T>(): Promise<T | null>;
+  deleteState(key: string): Promise<void>;
+}

--- a/test/actor/DemoActorDeleteStateInterface.ts
+++ b/test/actor/DemoActorDeleteStateInterface.ts
@@ -13,6 +13,6 @@ limitations under the License.
 
 export default interface DemoActorCounterInterface {
   init(): Promise<string>;
-  getState<T>(): Promise<T | null>;
+  tryGetState(): Promise<boolean | null>;
   deleteState(key: string): Promise<void>;
 }

--- a/test/e2e/http/actors.test.ts
+++ b/test/e2e/http/actors.test.ts
@@ -109,7 +109,7 @@ describe("http/actors", () => {
 
       const config = JSON.parse(await res.text());
 
-      expect(config.entities.length).toBe(8);
+      expect(config.entities.length).toBe(9);
       expect(config.actorIdleTimeout).toBe("1h");
       expect(config.actorScanInterval).toBe("30s");
       expect(config.drainOngoingCallTimeout).toBe("1m");
@@ -160,20 +160,22 @@ describe("http/actors", () => {
       const builder = new ActorProxyBuilder<DemoActorDeleteStateInterface>(DemoActorDeleteStateImpl, client);
       const actor = builder.build(ActorId.createRandomId());
       await actor.init();
-      const res = await actor.getState();
-      expect(res).toEqual(`Hello World!`);
+
+      const res = await actor.tryGetState();
+      expect(res).toEqual(true);
 
       await actor.deleteState("data");
-
-      const deletedRes = await actor.getState();
-      expect(deletedRes).toEqual(``);
+      
+      const deletedRes = await actor.tryGetState();
+      console.log(deletedRes);
+      expect(deletedRes).toEqual(false);
     });
   });
   describe("invoke", () => {
     it("should register actors correctly", async () => {
       const actors = await server.actor.getRegisteredActors();
 
-      expect(actors.length).toEqual(8);
+      expect(actors.length).toEqual(9);
 
       expect(actors).toContain(DemoActorCounterImpl.name);
       expect(actors).toContain(DemoActorSayImpl.name);

--- a/test/e2e/http/actors.test.ts
+++ b/test/e2e/http/actors.test.ts
@@ -165,7 +165,7 @@ describe("http/actors", () => {
       expect(res).toEqual(true);
 
       await actor.deleteState("data");
-      
+
       const deletedRes = await actor.tryGetState();
       console.log(deletedRes);
       expect(deletedRes).toEqual(false);

--- a/test/e2e/http/actors.test.ts
+++ b/test/e2e/http/actors.test.ts
@@ -29,6 +29,8 @@ import DemoActorTimerImpl from "../../actor/DemoActorTimerImpl";
 import DemoActorTimerInterface from "../../actor/DemoActorTimerInterface";
 import DemoActorTimerTtlImpl from "../../actor/DemoActorTimerTtlImpl";
 import DemoActorReminderTtlImpl from "../../actor/DemoActorReminderTtlImpl";
+import DemoActorDeleteStateImpl from "../../actor/DemoActorDeleteStateImpl";
+import DemoActorDeleteStateInterface from "../../actor/DemoActorDeleteStateInterface";
 
 const serverHost = "127.0.0.1";
 const serverPort = "50001";
@@ -84,6 +86,7 @@ describe("http/actors", () => {
     await server.actor.registerActor(DemoActorActivateImpl);
     await server.actor.registerActor(DemoActorTimerTtlImpl);
     await server.actor.registerActor(DemoActorReminderTtlImpl);
+    await server.actor.registerActor(DemoActorDeleteStateImpl);
 
     // Start server
     await server.start(); // Start the general server, this can take a while
@@ -152,6 +155,20 @@ describe("http/actors", () => {
     });
   });
 
+  describe("deleteActorState", () => {
+    it("should be able to delete actor state", async () => {
+      const builder = new ActorProxyBuilder<DemoActorDeleteStateInterface>(DemoActorDeleteStateImpl, client);
+      const actor = builder.build(ActorId.createRandomId());
+      await actor.init();
+      const res = await actor.getState();
+      expect(res).toEqual(`Hello World!`);
+
+      await actor.deleteState("data");
+
+      const deletedRes = await actor.getState();
+      expect(deletedRes).toEqual(``);
+    });
+  });
   describe("invoke", () => {
     it("should register actors correctly", async () => {
       const actors = await server.actor.getRegisteredActors();


### PR DESCRIPTION
# Description

There was a bug in the `saveState()` function in the StateProvider. For the states that are marked to be removed, the correct operation should be `delete` instead of `remove`. This bug caused the deletion of an dapr actor state to be unsuccessful.

## Issue reference


Please reference the issue this PR will close: #484 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
