### PR TITLE
bug(ci): explicitly call pre-build while building for publish steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prebuild": "./scripts/prebuild.sh",
     "build-ci": "npm run prebuild && ./scripts/build.sh",
-    "build": "npm install && npm run lint && npm run pretty && npm run build-ci",
+    "build": "npm install && npm run lint && npm run pretty && ./scripts/build.sh",
     "start:dev": "npm run build && nodemon --ext \".ts,.js\" --watch \"./src\" --exec \"npm run build\"",
     "pretty": "prettier --list-different \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "pretty-fix": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\""

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:unit:utils": "NODE_ENV=test npm run test:unit 'test/unit/utils/.*\\.test\\.ts'",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "prebuild": "./scripts/prebuild.sh",
-    "build-ci": "./scripts/build.sh",
+    "build-ci": "npm run prebuild && ./scripts/build.sh",
     "build": "npm install && npm run lint && npm run pretty && npm run build-ci",
     "start:dev": "npm run build && nodemon --ext \".ts,.js\" --watch \"./src\" --exec \"npm run build\"",
     "pretty": "prettier --list-different \"**/*.{ts,tsx,js,jsx,json,md}\"",


### PR DESCRIPTION
# Description

pre-build only gets triggered automatically when running `npm run build`.

For `npm run build-ci`, manually need to call pre-build.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
