### PR TITLE
updating config API to use v1 endpoint

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       GOVER: 1.19
       DAPR_CLI_VER: 1.10.0
-      DAPR_RUNTIME_VER: 1.10.0
+      DAPR_RUNTIME_VER: 1.11.0-rc.5
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF: ""
       DAPR_REF: ""

--- a/src/implementation/Client/GRPCClient/configuration.ts
+++ b/src/implementation/Client/GRPCClient/configuration.ts
@@ -56,7 +56,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     const client = await this.client.getClient();
 
     return new Promise((resolve, reject) => {
-      client.getConfigurationAlpha1(msg, metadata, (err, res: GetConfigurationResponse) => {
+      client.getConfiguration(msg, metadata, (err, res: GetConfigurationResponse) => {
         if (err) {
           return reject(err);
         }
@@ -122,7 +122,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     // and will stay open as long as the client is open
     // we will thus create a set with our listeners so we don't
     // break on multi listeners
-    const stream = client.subscribeConfigurationAlpha1(msg, metadata);
+    const stream = client.subscribeConfiguration(msg, metadata);
     let streamId: string;
 
     stream.on("data", async (data: SubscribeConfigurationResponse) => {
@@ -149,7 +149,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
           req.setStoreName(storeName);
           req.setId(streamId);
 
-          client.unsubscribeConfigurationAlpha1(req, (err, res: UnsubscribeConfigurationResponse) => {
+          client.unsubscribeConfiguration(req, (err, res: UnsubscribeConfigurationResponse) => {
             if (err || !res.getOk()) {
               return reject(res.getMessage());
             }


### PR DESCRIPTION
# Description

This PR updates configuration API implementation to use the v1 stable endpoint instead of alpha1 endpoint.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
