### PR TITLE
chore(release): bump to v3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dapr/dapr",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dapr/dapr",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dapr/dapr",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "The official Dapr (https://dapr.io) SDK for Node.js",
   "types": "./build/index.d.ts",
   "scripts": {


### PR DESCRIPTION
# Description

The last release did not have the correct version in lockfile which can cause errors/unexpected behavior, need to tag a new release.

