### PR TITLE
feat(pubsub): add wildcard support (+, #, $)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,14 +40,14 @@
   "author": "Xavier Geerinck",
   "license": "ISC",
   "dependencies": {
-    "@grpc/grpc-js": "^1.3.7",
+    "@grpc/grpc-js": "^1.9.3",
     "@js-temporal/polyfill": "^0.3.0",
     "@types/google-protobuf": "^3.15.5",
     "@types/node-fetch": "^2.6.2",
     "body-parser": "^1.19.0",
     "express": "^4.18.2",
     "google-protobuf": "^3.18.0",
-    "http-terminator": "^3.0.4",
+    "http-terminator": "^3.2.0",
     "node-fetch": "^2.6.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,13 +1,9 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@grpc/grpc-js':
-    specifier: ^1.3.7
-    version: 1.8.17
+    specifier: ^1.9.3
+    version: 1.9.3
   '@js-temporal/polyfill':
     specifier: ^0.3.0
     version: 0.3.0
@@ -27,8 +23,8 @@ dependencies:
     specifier: ^3.18.0
     version: 3.18.0
   http-terminator:
-    specifier: ^3.0.4
-    version: 3.0.4
+    specifier: ^3.2.0
+    version: 3.2.0
   node-fetch:
     specifier: ^2.6.7
     version: 2.6.7
@@ -442,22 +438,21 @@ packages:
       - supports-color
     dev: true
 
-  /@grpc/grpc-js@1.8.17:
-    resolution: {integrity: sha512-DGuSbtMFbaRsyffMf+VEkVu8HkSXEUfO3UyGJNtqxW9ABdtTIA+2UXAJpwbJS+xfQxuwqLUeELmL6FuZkOqPxw==}
+  /@grpc/grpc-js@1.9.3:
+    resolution: {integrity: sha512-b8iWtdrYIeT5fdZdS4Br/6h/kuk0PW5EVBUGk1amSbrpL8DlktJD43CdcCWwRdd6+jgwHhADSbL9CsNnm6EUPA==}
     engines: {node: ^8.13.0 || >=10.10.0}
     dependencies:
-      '@grpc/proto-loader': 0.7.7
+      '@grpc/proto-loader': 0.7.10
       '@types/node': 16.9.1
     dev: false
 
-  /@grpc/proto-loader@0.7.7:
-    resolution: {integrity: sha512-1TIeXOi8TuSCQprPItwoMymZXxWT0CPxUhkrkeCUH+D8U7QDwQ6b7SUz2MaLuWM2llT+J/TVFLmQI5KtML3BhQ==}
+  /@grpc/proto-loader@0.7.10:
+    resolution: {integrity: sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==}
     engines: {node: '>=6'}
     hasBin: true
     dependencies:
-      '@types/long': 4.0.2
       lodash.camelcase: 4.3.0
-      long: 4.0.0
+      long: 5.2.3
       protobufjs: 7.2.4
       yargs: 17.7.2
     dev: false
@@ -902,10 +897,6 @@ packages:
   /@types/json-schema@7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
-
-  /@types/long@4.0.2:
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-    dev: false
 
   /@types/mime@3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
@@ -2359,9 +2350,9 @@ packages:
       - supports-color
     dev: true
 
-  /http-terminator@3.0.4:
-    resolution: {integrity: sha512-9xQ5RFxwBxuGJhFgaBzykLUkSYRPyOb2xcR3EAYzj4Y8WteWmu5zsfEQncxLiyCJQHCdAexjuDcciUqw9W3/Sw==}
-    engines: {node: '>=10'}
+  /http-terminator@3.2.0:
+    resolution: {integrity: sha512-JLjck1EzPaWjsmIf8bziM3p9fgR1Y3JoUKAkyYEbZmFrIvJM6I8vVJfBGWlEtV9IWOvzNnaTtjuwZeBY2kwB4g==}
+    engines: {node: '>=14'}
     dependencies:
       delay: 5.0.0
       p-wait-for: 3.2.0
@@ -3161,10 +3152,6 @@ packages:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
     dev: true
 
-  /long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
-    dev: false
-
   /long@5.2.3:
     resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
     dev: false
@@ -3950,6 +3937,7 @@ packages:
 
   /string-similarity@4.0.4:
     resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     dev: false
 
   /string-width@4.2.3:
@@ -4436,3 +4424,7 @@ packages:
       y18n: 5.0.8
       yargs-parser: 21.1.1
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/implementation/Client/GRPCClient/GRPCClientProxy.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClientProxy.ts
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import * as grpc from "@grpc/grpc-js";
-import { InterceptingListener } from "@grpc/grpc-js/build/src/call-stream";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
 import Class from "../../../types/Class";
 import { Settings } from "../../../utils/Settings.util";
@@ -37,8 +36,8 @@ export class GRPCClientProxy<T> {
       return new grpc.InterceptingCall(nextCall(options), {
         start: (
           metadata: grpc.Metadata,
-          listener: InterceptingListener,
-          next: (metadata: grpc.Metadata, listener: InterceptingListener | grpc.Listener) => void,
+          listener: grpc.InterceptingListener,
+          next: (metadata: grpc.Metadata, listener: grpc.InterceptingListener | grpc.Listener) => void,
         ) => {
           metadata.add("dapr-app-id", `${Settings.getAppId()}`);
           next(metadata, listener);

--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
+import crypto from "node:crypto";
 import HTTPClient from "./HTTPClient";
 import IClientPubSub from "../../../interfaces/Client/IClientPubSub";
 import { Logger } from "../../../logger/Logger";
@@ -33,6 +33,14 @@ export default class HTTPClientPubSub implements IClientPubSub {
     this.logger = new Logger("HTTPClient", "PubSub", client.options.logger);
   }
 
+  /**
+   * Encodes the topic name to be used in the URL in a safe way for HTTP Communication
+   */
+  _encodeTopic(topic: string): string {
+    return crypto.createHash("md5").update(topic).digest("hex").toString();
+    // return encodeURIComponent(topic);
+  }
+
   async publish(
     pubSubName: string,
     topic: string,
@@ -49,7 +57,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     }
 
     try {
-      await this.client.execute(`/publish/${pubSubName}/${topic}?${queryParams}`, {
+      await this.client.execute(`/publish/${pubSubName}/${this._encodeTopic(topic)}?${queryParams}`, {
         method: "POST",
         body: data,
         headers,
@@ -82,7 +90,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     try {
       await this.client.executeWithApiVersion(
         "v1.0-alpha1",
-        `/publish/bulk/${pubSubName}/${topic}?${queryParams}`,
+        `/publish/bulk/${pubSubName}/${this._encodeTopic(topic)}?${queryParams}`,
         params,
       );
     } catch (error: any) {

--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import crypto from "node:crypto";
 import HTTPClient from "./HTTPClient";
 import IClientPubSub from "../../../interfaces/Client/IClientPubSub";

--- a/src/implementation/Client/HTTPClient/pubsub.ts
+++ b/src/implementation/Client/HTTPClient/pubsub.ts
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import crypto from "node:crypto";
 import HTTPClient from "./HTTPClient";
 import IClientPubSub from "../../../interfaces/Client/IClientPubSub";
 import { Logger } from "../../../logger/Logger";
@@ -34,14 +33,6 @@ export default class HTTPClientPubSub implements IClientPubSub {
     this.logger = new Logger("HTTPClient", "PubSub", client.options.logger);
   }
 
-  /**
-   * Encodes the topic name to be used in the URL in a safe way for HTTP Communication
-   */
-  _encodeTopic(topic: string): string {
-    return crypto.createHash("md5").update(topic).digest("hex").toString();
-    // return encodeURIComponent(topic);
-  }
-
   async publish(
     pubSubName: string,
     topic: string,
@@ -58,7 +49,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     }
 
     try {
-      await this.client.execute(`/publish/${pubSubName}/${this._encodeTopic(topic)}?${queryParams}`, {
+      await this.client.execute(`/publish/${pubSubName}/${topic}?${queryParams}`, {
         method: "POST",
         body: data,
         headers,
@@ -91,7 +82,7 @@ export default class HTTPClientPubSub implements IClientPubSub {
     try {
       await this.client.executeWithApiVersion(
         "v1.0-alpha1",
-        `/publish/bulk/${pubSubName}/${this._encodeTopic(topic)}?${queryParams}`,
+        `/publish/bulk/${pubSubName}/${topic}?${queryParams}`,
         params,
       );
     } catch (error: any) {

--- a/src/implementation/Server/GRPCServer/GRPCServer.ts
+++ b/src/implementation/Server/GRPCServer/GRPCServer.ts
@@ -117,16 +117,7 @@ export default class GRPCServer implements IServer {
   }
 
   async stop(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      this.server.tryShutdown((err) => {
-        if (err) {
-          return reject(err);
-        }
-
-        this.isInitialized = false;
-        return resolve();
-      });
-    });
+    this.server.forceShutdown();
   }
 
   private async initializeBind(): Promise<void> {

--- a/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
+++ b/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
@@ -321,7 +321,8 @@ export default class GRPCServerImpl implements IAppCallbackServer {
       routeParsed = routeParsed.replace("/", ""); // will only remove first occurence
     }
 
-    return `${pubsubName.toLowerCase()}--${topic.toLowerCase()}--${routeParsed}`;
+    const routeGenerated = `${pubsubName.toLowerCase()}--${topic.toLowerCase()}--${routeParsed}`;
+    return encodeURIComponent(routeGenerated);
   }
 
   registerInputBindingHandler(bindingName: string, cb: DaprInvokerCallbackFunction): void {
@@ -413,6 +414,11 @@ export default class GRPCServerImpl implements IAppCallbackServer {
 
     const pubsubName = req.getPubsubName();
     const topic = req.getTopic();
+
+    console.log("DEBUG - GOT ITEM FOR ", topic);
+
+    // const routeObj = this.pubSubSubscriptions[pubsubName][topic].routes[route];
+    // this.server.post(`/${routeObj.path}`, async (req, res) => {
 
     // Route is unique to pubsub and topic and has format pubsub--topic--route so we strip it since else we can't find the route
     const route = this.generatePubSubSubscriptionTopicRouteName(req.getPath().replace(`${pubsubName}--${topic}--`, ""));

--- a/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import crypto from "node:crypto";
 import { Logger } from "../../../logger/Logger";
 import { LoggerOptions } from "../../../types/logger/LoggerOptions";
 import { DaprPubSubType } from "../../../types/pubsub/DaprPubSub.type";
@@ -311,11 +310,6 @@ export default class HTTPServerImpl {
     return routes;
   }
 
-  _encodeTopic(topic: string): string {
-    return crypto.createHash("md5").update(topic).digest("hex").toString();
-    return encodeURIComponent(topic);
-  }
-
   generateDaprSubscriptionRoute(
     pubsubName: string,
     topic: string,
@@ -357,7 +351,7 @@ export default class HTTPServerImpl {
     if (!options || !options?.route) {
       return {
         pubsubname: pubsubName,
-        topic: this._encodeTopic(topic),
+        topic: topic,
         metadata: metadata,
         route: this.generateDaprSubscriptionRoute(pubsubName, topic),
         deadLetterTopic: options.deadLetterTopic,
@@ -366,7 +360,7 @@ export default class HTTPServerImpl {
     } else if (typeof options.route === "string") {
       return {
         pubsubname: pubsubName,
-        topic: this._encodeTopic(topic),
+        topic: topic,
         metadata: metadata,
         route: this.generateDaprSubscriptionRoute(pubsubName, topic, options.route),
         deadLetterTopic: options.deadLetterTopic,
@@ -375,7 +369,7 @@ export default class HTTPServerImpl {
     } else {
       return {
         pubsubname: pubsubName,
-        topic: this._encodeTopic(topic),
+        topic: topic,
         metadata: metadata,
         routes: options.route && {
           default: this.generateDaprSubscriptionRoute(pubsubName, topic, options.route?.default),
@@ -430,7 +424,6 @@ export default class HTTPServerImpl {
 
     // Create an MD5 hash of the topic name
     // This is to ensure that we have a unique path for each topic that is url safe
-    const encodedTopic = this._encodeTopic(topic);
-    return `${pubsubName.toLowerCase()}--${encodedTopic}--${routeParsed}`;
+    return `${pubsubName.toLowerCase()}--${topic.toLowerCase()}--${routeParsed}`;
   }
 }

--- a/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
@@ -10,6 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 import crypto from "node:crypto";
 import { Logger } from "../../../logger/Logger";
 import { LoggerOptions } from "../../../types/logger/LoggerOptions";

--- a/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServerImpl.ts
@@ -422,8 +422,7 @@ export default class HTTPServerImpl {
       routeParsed = routeParsed.replace("/", ""); // will only remove first occurence
     }
 
-    // Create an MD5 hash of the topic name
-    // This is to ensure that we have a unique path for each topic that is url safe
-    return `${pubsubName.toLowerCase()}--${topic.toLowerCase()}--${routeParsed}`;
+    const routeGenerated = `${pubsubName.toLowerCase()}--${topic}--${routeParsed}`;
+    return encodeURIComponent(routeGenerated);
   }
 }

--- a/test/components/common/pubsub-mqtt.yaml
+++ b/test/components/common/pubsub-mqtt.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright 2022 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# https://docs.dapr.io/reference/components-reference/supported-bindings/rabbitmq/
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: pubsub-mqtt
+  namespace: default
+spec:
+  type: pubsub.mqtt
+  version: v1
+  metadata:
+  - name: url
+    value: "tcp://admin:public@localhost:1883"
+  - name: qos
+    value: 1
+  - name: cleanSession
+    value: "true"
+  - name: backOffMaxRetries
+    value: "0"

--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -699,8 +699,7 @@ describe("common/server", () => {
     runIt(
       "should allow us to subscribe to wildcard topics with a + (e.g., /app/+/event)",
       async (server: DaprServer, protocol: string) => {
-        console.log(getTopic(topicWildcardPlus, protocol));
-        const res = await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardPlus, protocol), {
+        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardPlus, protocol), {
           message: "Hello, world!",
         });
 
@@ -715,7 +714,7 @@ describe("common/server", () => {
     runIt(
       "should allow us to subscribe to wildcard topics with a # (e.g., /app/#)",
       async (server: DaprServer, protocol: string) => {
-        const res = await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardHash, protocol), {
+        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardHash, protocol), {
           message: "Hello, world!",
         });
 
@@ -730,7 +729,7 @@ describe("common/server", () => {
     runIt(
       "should allow us to subscribe to wildcard topics with a $ (e.g., $SYS/broker/clients/connected)",
       async (server: DaprServer, protocol: string) => {
-        const res = await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardLeadingDollar, protocol), {
+        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardLeadingDollar, protocol), {
           message: "Hello, world!",
         });
 

--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -697,9 +697,9 @@ describe("common/server", () => {
     );
 
     runIt(
-      "should allow us to subscribe to wildcard topics with a + (e.g., /app/+/event)",
+      "should allow us to subscribe to wildcard topics with a + (e.g., myhome/groundfloor/+/temperature) - single level wildcard",
       async (server: DaprServer, protocol: string) => {
-        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardPlus, protocol), {
+        await server.client.pubsub.publish(pubSubName, getTopic("myhome/groundfloor/test/temperature", protocol), {
           message: "Hello, world!",
         });
 
@@ -712,9 +712,9 @@ describe("common/server", () => {
     );
 
     runIt(
-      "should allow us to subscribe to wildcard topics with a # (e.g., /app/#)",
+      "should allow us to subscribe to wildcard topics with a # (e.g., myhome/groundfloor/#) - multi level wildcard",
       async (server: DaprServer, protocol: string) => {
-        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardHash, protocol), {
+        await server.client.pubsub.publish(pubSubName, getTopic("myhome/groundfloor/test1/test2", protocol), {
           message: "Hello, world!",
         });
 
@@ -727,14 +727,12 @@ describe("common/server", () => {
     );
 
     runIt(
-      "should allow us to subscribe to wildcard topics with a $ (e.g., $SYS/broker/clients/connected)",
+      "should allow us to subscribe to wildcard topics with a $ (e.g., $SYS/broker/messages/sent)",
       async (server: DaprServer, protocol: string) => {
-        await server.client.pubsub.publish(pubSubName, getTopic(topicWildcardLeadingDollar, protocol), {
-          message: "Hello, world!",
-        });
-
         // Delay a bit for event to arrive
         await new Promise((resolve, _reject) => setTimeout(resolve, 250));
+
+        console.log(mockSubscribeHandler.mock.calls.length);
 
         expect(mockSubscribeHandler.mock.calls.length).toBe(1);
         expect(mockSubscribeHandler.mock.calls[0][0]).toEqual({ message: "Hello, world!" });

--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -728,7 +728,7 @@ describe("common/server", () => {
 
     runIt(
       "should allow us to subscribe to wildcard topics with a $ (e.g., $SYS/broker/messages/sent)",
-      async (server: DaprServer, protocol: string) => {
+      async (_server: DaprServer, _protocol: string) => {
         // Delay a bit for event to arrive
         await new Promise((resolve, _reject) => setTimeout(resolve, 250));
 

--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -54,7 +54,13 @@ describe("common/server", () => {
   let httpServer: DaprServer;
   let grpcServer: DaprServer;
 
-  const getTopic = (topic: string, protocol: string) => topic + "-" + protocol;
+  const getTopic = (topic: string, protocol: string) => {
+    if (protocol.indexOf("/") > -1) {
+      return protocol + "/" + topic;
+    } else {
+      return protocol + "-" + topic;
+    }
+  };
   const mockSubscribeHandler = jest.fn(async (_data: object, _headers: object) => null);
   const mockBulkSubscribeRawPayloadHandler = jest.fn(async (_data: object, _headers: object) => null);
   const mockBulkSubscribeCEHandler = jest.fn(async (_data: object, _headers: object) => null);

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -21,7 +21,6 @@ import { SubscribeConfigurationResponse } from "../../../src/types/configuration
 import * as DockerUtils from "../../utils/DockerUtil";
 import { DaprClient as DaprClientGrpc } from "../../../src/proto/dapr/proto/runtime/v1/dapr_grpc_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
-import { InterceptingListener } from "@grpc/grpc-js/build/src/call-stream";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
 
 const daprHost = "localhost";
@@ -64,8 +63,8 @@ describe("grpc/client", () => {
         return new grpc.InterceptingCall(nextCall(options), {
           start: function (
             metadata: grpc.Metadata,
-            listener: InterceptingListener,
-            next: (metadata: grpc.Metadata, listener: InterceptingListener | grpc.Listener) => void,
+            listener: grpc.InterceptingListener,
+            next: (metadata: grpc.Metadata, listener: grpc.InterceptingListener | grpc.Listener) => void,
           ) {
             mockMetadataRes = metadata;
             next(metadata, listener);
@@ -92,8 +91,8 @@ describe("grpc/client", () => {
         return new grpc.InterceptingCall(nextCall(options), {
           start: function (
             metadata: grpc.Metadata,
-            listener: InterceptingListener,
-            next: (metadata: grpc.Metadata, listener: InterceptingListener | grpc.Listener) => void,
+            listener: grpc.InterceptingListener,
+            next: (metadata: grpc.Metadata, listener: grpc.InterceptingListener | grpc.Listener) => void,
           ) {
             mockMetadataRes = metadata;
             next(metadata, listener);


### PR DESCRIPTION
# Description

This PR adds wildcard support on the PubSub system. This was not possible before due to the way routes were used in unique route registrations. This PR modifies how a route is registered by creating an MD5 of the topic.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #516 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
