### PR TITLE
Replacing callbacks

### DIFF
--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -100,21 +100,11 @@ export default class GRPCClient implements IClient {
     const deadline = Date.now() + Settings.getDaprSidecarStartupTimeoutMs();
 
     try {
-      await promisify(this.client.waitForReady)(deadline);
+      await promisify(this.client.waitForReady).bind(this.client)(deadline);
     } catch (err) {
       this.logger.error(`Error waiting for client to be ready: ${err}`);
-      throw err;
+      throw undefined;
     }
-    /* return new Promise((resolve, reject) => {
-      this.client.waitForReady(deadline, (err?) => {
-        if (err) {
-          this.logger.error(`Error waiting for client to be ready: ${err}`);
-          return reject();
-        }
-
-        return resolve();
-      });
-    });*/
   }
 
   async _startAwaitSidecarStarted(): Promise<void> {

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -20,6 +20,7 @@ import { Logger } from "../../../logger/Logger";
 import GRPCClientSidecar from "./sidecar";
 import DaprClient from "../DaprClient";
 import { SDK_VERSION } from "../../../version";
+import { promisify } from "util";
 
 export default class GRPCClient implements IClient {
   readonly options: DaprClientOptions;
@@ -98,7 +99,13 @@ export default class GRPCClient implements IClient {
   async _startWaitForClientReady(): Promise<void> {
     const deadline = Date.now() + Settings.getDaprSidecarStartupTimeoutMs();
 
-    return new Promise((resolve, reject) => {
+    try {
+      await promisify(this.client.waitForReady)(deadline);
+    } catch (err) {
+      this.logger.error(`Error waiting for client to be ready: ${err}`);
+      throw err;
+    }
+    /* return new Promise((resolve, reject) => {
       this.client.waitForReady(deadline, (err?) => {
         if (err) {
           this.logger.error(`Error waiting for client to be ready: ${err}`);
@@ -107,7 +114,7 @@ export default class GRPCClient implements IClient {
 
         return resolve();
       });
-    });
+    });*/
   }
 
   async _startAwaitSidecarStarted(): Promise<void> {

--- a/src/implementation/Client/GRPCClient/binding.ts
+++ b/src/implementation/Client/GRPCClient/binding.ts
@@ -43,26 +43,13 @@ export default class GRPCClientBinding implements IClientBinding {
 
     const client = await this.client.getClient();
 
-    const res = await promisify<InvokeBindingRequest, InvokeBindingResponse>(client.invokeBinding)(msgService);
+    const invokeBinding = promisify<InvokeBindingRequest, InvokeBindingResponse>(client.invokeBinding).bind(client);
+    const res = await invokeBinding(msgService);
 
     return {
       data: res.getData(),
       metadata: res.getMetadataMap(),
       operation,
     };
-    /*return new Promise((resolve, reject) => {
-      client.invokeBinding(msgService, (err, res: InvokeBindingResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        // https://docs.dapr.io/reference/api/bindings_api/#payload
-        return resolve({
-          data: res.getData(),
-          metadata: res.getMetadataMap(),
-          operation,
-        });
-      });
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/binding.ts
+++ b/src/implementation/Client/GRPCClient/binding.ts
@@ -17,6 +17,7 @@ import IClientBinding from "../../../interfaces/Client/IClientBinding";
 import * as SerializerUtil from "../../../utils/Serializer.util";
 import { addMetadataToMap } from "../../../utils/Client.util";
 import { KeyValueType } from "../../../types/KeyValue.type";
+import { promisify } from "util";
 
 // https://docs.dapr.io/reference/api/bindings_api/
 export default class GRPCClientBinding implements IClientBinding {
@@ -42,7 +43,14 @@ export default class GRPCClientBinding implements IClientBinding {
 
     const client = await this.client.getClient();
 
-    return new Promise((resolve, reject) => {
+    const res = await promisify<InvokeBindingRequest, InvokeBindingResponse>(client.invokeBinding)(msgService);
+
+    return {
+      data: res.getData(),
+      metadata: res.getMetadataMap(),
+      operation,
+    };
+    /*return new Promise((resolve, reject) => {
       client.invokeBinding(msgService, (err, res: InvokeBindingResponse) => {
         if (err) {
           return reject(err);
@@ -55,6 +63,6 @@ export default class GRPCClientBinding implements IClientBinding {
           operation,
         });
       });
-    });
+    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/configuration.ts
+++ b/src/implementation/Client/GRPCClient/configuration.ts
@@ -166,7 +166,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
             client.unsubscribeConfiguration,
           );
           res = await unsubscribe(req);
-          hasError = !res.getOk()
+          hasError = !res.getOk();
         } catch (e) {
           hasError = true;
         }

--- a/src/implementation/Client/GRPCClient/configuration.ts
+++ b/src/implementation/Client/GRPCClient/configuration.ts
@@ -58,7 +58,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
 
     const getConfiguration = promisify<GetConfigurationRequest, grpc.Metadata, GetConfigurationResponse>(
       client.getConfiguration,
-    );
+    ).bind(client);
     const res = await getConfiguration(msg, metadata);
 
     const configMap: { [k: string]: ConfigurationItem } = createConfigurationType(res.getItemsMap());
@@ -66,21 +66,6 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     return {
       items: configMap,
     };
-    /*return new Promise((resolve, reject) => {
-      client.getConfiguration(msg, metadata, (err, res: GetConfigurationResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        const configMap: { [k: string]: ConfigurationItem } = createConfigurationType(res.getItemsMap());
-
-        const result: SubscribeConfigurationResponseResult = {
-          items: configMap,
-        };
-
-        return resolve(result);
-      });
-    });*/
   }
 
   async subscribe(storeName: string, cb: SubscribeConfigurationCallback): Promise<SubscribeConfigurationStream> {
@@ -164,7 +149,8 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
         try {
           const unsubscribe = promisify<UnsubscribeConfigurationRequest, UnsubscribeConfigurationResponse>(
             client.unsubscribeConfiguration,
-          );
+          ).bind(client);
+
           res = await unsubscribe(req);
           hasError = !res.getOk();
         } catch (e) {
@@ -180,30 +166,5 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
         stream.destroy();
       },
     };
-    /*return {
-      stop: async () => {
-        return new Promise((resolve, reject) => {
-          const req = new UnsubscribeConfigurationRequest();
-          req.setStoreName(storeName);
-          req.setId(streamId);
-
-          const unsubscribe = promisify<UnsubscribeConfigurationRequest, UnsubscribeConfigurationResponse>(
-            client.unsubscribeConfiguration,
-          );
-          const res = await unsubscribe(req);
-          client.unsubscribeConfiguration(req, (err, res: UnsubscribeConfigurationResponse) => {
-            if (err || !res.getOk()) {
-              return reject(res.getMessage());
-            }
-
-            // Clean up the node.js event emitter
-            stream.removeAllListeners();
-            stream.destroy();
-
-            return resolve();
-          });
-        });
-      },
-    };*/
   }
 }

--- a/src/implementation/Client/GRPCClient/health.ts
+++ b/src/implementation/Client/GRPCClient/health.ts
@@ -31,25 +31,12 @@ export default class GRPCClientHealth implements IClientHealth {
 
     let isHealthy = true;
     try {
-      await promisify(client.getMetadata)(new Empty());
+      const getMetadata = promisify(client.getMetadata).bind(client);
+      await getMetadata(new Empty());
     } catch (e) {
       isHealthy = false;
     }
 
     return isHealthy;
-
-    /*return new Promise((resolve, _reject) => {
-      try {
-        client.getMetadata(new Empty(), (err, _res: GetMetadataResponse) => {
-          if (err) {
-            return resolve(false);
-          }
-
-          return resolve(true);
-        });
-      } catch (e) {
-        return resolve(false);
-      }
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/health.ts
+++ b/src/implementation/Client/GRPCClient/health.ts
@@ -15,6 +15,7 @@ import GRPCClient from "./GRPCClient";
 import IClientHealth from "../../../interfaces/Client/IClientHealth";
 import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { promisify } from "util";
 
 // https://docs.dapr.io/reference/api/health_api/
 export default class GRPCClientHealth implements IClientHealth {
@@ -28,7 +29,16 @@ export default class GRPCClientHealth implements IClientHealth {
   async isHealthy(): Promise<boolean> {
     const client = await this.client.getClient();
 
-    return new Promise((resolve, _reject) => {
+    let isHealthy = true;
+    try {
+      await promisify(client.getMetadata)(new Empty());
+    } catch (e) {
+      isHealthy = false;
+    }
+
+    return isHealthy;
+
+    /*return new Promise((resolve, _reject) => {
       try {
         client.getMetadata(new Empty(), (err, _res: GetMetadataResponse) => {
           if (err) {
@@ -40,6 +50,6 @@ export default class GRPCClientHealth implements IClientHealth {
       } catch (e) {
         return resolve(false);
       }
-    });
+    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/health.ts
+++ b/src/implementation/Client/GRPCClient/health.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import GRPCClient from "./GRPCClient";
 import IClientHealth from "../../../interfaces/Client/IClientHealth";
-import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+//import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { promisify } from "util";
 

--- a/src/implementation/Client/GRPCClient/invoker.ts
+++ b/src/implementation/Client/GRPCClient/invoker.ts
@@ -61,7 +61,8 @@ export default class GRPCClientInvoker implements IClientInvoker {
 
     const client = await this.client.getClient();
 
-    const res = await promisify<InvokeServiceRequest, InvokeResponse>(client.invokeService)(msgInvokeService);
+    const invokeService = promisify<InvokeServiceRequest, InvokeResponse>(client.invokeService).bind(client);
+    const res = await invokeService(msgInvokeService);
     let resData = "";
 
     if (res.getData()) {
@@ -78,31 +79,5 @@ export default class GRPCClientInvoker implements IClientInvoker {
         }),
       );
     }
-
-    /*return new Promise((resolve, reject) => {
-      client.invokeService(msgInvokeService, (err, res: InvokeResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        let resData = "";
-
-        if (res.getData()) {
-          resData = Buffer.from((res.getData() as Any).getValue()).toString();
-        }
-
-        try {
-          const parsedResData = JSON.parse(resData);
-          return resolve(parsedResData);
-        } catch (e) {
-          throw new Error(
-            JSON.stringify({
-              error: "COULD_NOT_PARSE_RESULT",
-              error_msg: `Could not parse the returned resultset: ${resData}`,
-            }),
-          );
-        }
-      });
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/lock.ts
+++ b/src/implementation/Client/GRPCClient/lock.ts
@@ -43,50 +43,25 @@ export default class GRPCClientLock implements IClientLock {
       .setExpiryInSeconds(expiryInSeconds);
 
     const client = await this.client.getClient();
-    const res = await promisify<TryLockRequest, TryLockResponse>(client.tryLockAlpha1)(request);
+    const tryLock = promisify<TryLockRequest, TryLockResponse>(client.tryLockAlpha1).bind(client);
+    const res = await tryLock(request);
 
     return {
       success: res.getSuccess(),
     };
-
-    /* return new Promise((resolve, reject) => {
-      client.tryLockAlpha1(request, (err, res: TryLockResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        const wrapped: LockResponseResult = {
-          success: res.getSuccess(),
-        };
-
-        return resolve(wrapped);
-      });
-    });*/
   }
 
   async unlock(storeName: string, resourceId: string, lockOwner: string): Promise<UnLockResponseResult> {
     const request = new UnlockRequest().setStoreName(storeName).setResourceId(resourceId).setLockOwner(lockOwner);
 
     const client = await this.client.getClient();
-    const res = await promisify<UnlockRequest, UnlockResponse>(client.unlockAlpha1)(request);
+
+    const unlock = promisify<UnlockRequest, UnlockResponse>(client.unlockAlpha1).bind(client);
+    const res = await unlock(request);
 
     return {
       status: this.getUnlockResponse(res),
     };
-
-    /*return new Promise((resolve, reject) => {
-      client.unlockAlpha1(request, (err, res: UnlockResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        const wrapped: UnLockResponseResult = {
-          status: this.getUnlockResponse(res),
-        };
-
-        return resolve(wrapped);
-      });
-    });*/
   }
 
   getUnlockResponse(res: UnlockResponse) {

--- a/src/implementation/Client/GRPCClient/metadata.ts
+++ b/src/implementation/Client/GRPCClient/metadata.ts
@@ -30,7 +30,8 @@ export default class GRPCClientMetadata implements IClientMetadata {
   async get(): Promise<GetMetadataResponseResult> {
     const client = await this.client.getClient();
 
-    const res = await promisify<Empty, GetMetadataResponse>(client.getMetadata)(new Empty());
+    const getMetadata = promisify<Empty, GetMetadataResponse>(client.getMetadata).bind(client);
+    const res = await getMetadata(new Empty());
 
     return {
       id: res.getId(),
@@ -53,37 +54,6 @@ export default class GRPCClientMetadata implements IClientMetadata {
         capabilities: c.getCapabilitiesList(),
       })),
     };
-    /*return new Promise((resolve, reject) => {
-      client.getMetadata(new Empty(), (err, res: GetMetadataResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        const wrapped: GetMetadataResponseResult = {
-          id: res.getId(),
-          actors: res.getActiveActorsCountList().map((a) => ({
-            type: a.getType(),
-            count: a.getCount(),
-          })),
-          extended: res
-            .getExtendedMetadataMap()
-            .toObject()
-            .reduce((result: object, [key, value]) => {
-              // @ts-ignore
-              result[key] = value;
-              return result;
-            }, {}),
-          components: res.getRegisteredComponentsList().map((c) => ({
-            name: c.getName(),
-            type: c.getType(),
-            version: c.getVersion(),
-            capabilities: c.getCapabilitiesList(),
-          })),
-        };
-
-        return resolve(wrapped);
-      });
-    });*/
   }
 
   async set(key: string, value: string): Promise<boolean> {
@@ -94,20 +64,12 @@ export default class GRPCClientMetadata implements IClientMetadata {
     const client = await this.client.getClient();
 
     try {
-      await promisify<SetMetadataRequest, Empty>(client.setMetadata)(msg);
+      const setMetadata = promisify(client.setMetadata).bind(client);
+      await setMetadata(msg);
     } catch (e) {
       throw false;
     }
 
     return true;
-    /*return new Promise((resolve, reject) => {
-      client.setMetadata(msg, (err, _res: Empty) => {
-        if (err) {
-          return reject(false);
-        }
-
-        return resolve(true);
-      });
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/pubsub.ts
+++ b/src/implementation/Client/GRPCClient/pubsub.ts
@@ -62,24 +62,14 @@ export default class GRPCClientPubSub implements IClientPubSub {
     const client = await this.client.getClient();
 
     try {
-      await promisify(client.publishEvent)(msgService);
+      const publishEvent = promisify(client.publishEvent).bind(client);
+      await publishEvent(msgService);
     } catch (err) {
       this.logger.error(`publish failed: ${err}`);
       throw { error: err };
     }
 
     return {};
-
-    /*return new Promise((resolve, reject) => {
-      client.publishEvent(msgService, (err, _res) => {
-        if (err) {
-          this.logger.error(`publish failed: ${err}`);
-          return reject({ error: err });
-        }
-
-        return resolve({});
-      });
-    });*/
   }
 
   async publishBulk(
@@ -107,7 +97,9 @@ export default class GRPCClientPubSub implements IClientPubSub {
 
     const client = await this.client.getClient();
     try {
-      const bulkPublish = promisify<BulkPublishRequest, BulkPublishResponse>(client.bulkPublishEventAlpha1);
+      const bulkPublish = promisify<BulkPublishRequest, BulkPublishResponse>(client.bulkPublishEventAlpha1).bind(
+        client,
+      );
       const res = await bulkPublish(bulkPublishRequest);
 
       const failedEntries = res.getFailedentriesList();
@@ -127,29 +119,5 @@ export default class GRPCClientPubSub implements IClientPubSub {
     }
 
     return { failedMessages: [] };
-    /*return new Promise((resolve, _reject) => {
-      client.bulkPublishEventAlpha1(bulkPublishRequest, (err, res) => {
-        if (err) {
-          return resolve(getBulkPublishResponse({ entries: entries, error: err }));
-        }
-
-        const failedEntries = res.getFailedentriesList();
-        if (failedEntries.length > 0) {
-          return resolve(
-            getBulkPublishResponse({
-              entries: entries,
-              response: {
-                failedEntries: failedEntries.map((entry) => ({
-                  entryID: entry.getEntryId(),
-                  error: entry.getError(),
-                })),
-              },
-            }),
-          );
-        }
-
-        return resolve({ failedMessages: [] });
-      });
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/secret.ts
+++ b/src/implementation/Client/GRPCClient/secret.ts
@@ -37,7 +37,9 @@ export default class GRPCClientSecret implements IClientSecret {
 
     const client = await this.client.getClient();
 
-    const res = await promisify<GetSecretRequest, GetSecretResponse>(client.getSecret)(msgService);
+    const getSecret = promisify<GetSecretRequest, GetSecretResponse>(client.getSecret).bind(client);
+    const res = await getSecret(msgService);
+
     // Convert [ [ 'TEST_SECRET_1', 'secret_val_1' ] ] => [ { TEST_SECRET_1: 'secret_val_1' } ]
     const items = res
       .getDataMap()
@@ -45,22 +47,6 @@ export default class GRPCClientSecret implements IClientSecret {
       .map((item) => ({ [item[0]]: item[1] }));
 
     return items[0];
-    /*return new Promise((resolve, reject) => {
-      client.getSecret(msgService, (err, res: GetSecretResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        // Convert [ [ 'TEST_SECRET_1', 'secret_val_1' ] ] => [ { TEST_SECRET_1: 'secret_val_1' } ]
-        const items = res
-          .getDataMap()
-          .getEntryList()
-          .map((item) => ({ [item[0]]: item[1] }));
-
-        // Return first item (it's a single get)
-        return resolve(items[0]);
-      });
-    });*/
   }
 
   async getBulk(secretStoreName: string): Promise<object> {
@@ -69,23 +55,12 @@ export default class GRPCClientSecret implements IClientSecret {
 
     const client = await this.client.getClient();
 
-    const res = await promisify<GetBulkSecretRequest, GetBulkSecretResponse>(client.getBulkSecret)(msgService);
+    const getBulkSecret = promisify<GetBulkSecretRequest, GetBulkSecretResponse>(client.getBulkSecret).bind(client);
+    const res = await getBulkSecret(msgService);
 
     // https://docs.dapr.io/reference/api/secrets_api/#response-body-1
     // @ts-ignore
     // tslint:disable-next-line
     return res.getDataMap()["map_"];
-    /*return new Promise((resolve, reject) => {
-      client.getBulkSecret(msgService, (err, res: GetBulkSecretResponse) => {
-        if (err) {
-          return reject(err);
-        }
-
-        // https://docs.dapr.io/reference/api/secrets_api/#response-body-1
-        // @ts-ignore
-        // tslint:disable-next-line
-        return resolve(res.getDataMap()["map_"]);
-      });
-    });*/
   }
 }

--- a/src/implementation/Client/GRPCClient/sidecar.ts
+++ b/src/implementation/Client/GRPCClient/sidecar.ts
@@ -15,6 +15,7 @@ import GRPCClient from "./GRPCClient";
 import IClientSidecar from "../../../interfaces/Client/IClientSidecar";
 import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
+import { promisify } from "util";
 
 // https://docs.dapr.io/reference/api/secrets_api/
 export default class GRPCClientSidecar implements IClientSidecar {
@@ -27,7 +28,8 @@ export default class GRPCClientSidecar implements IClientSidecar {
   async shutdown(): Promise<void> {
     const client = await this.client.getClient();
 
-    return new Promise((resolve, reject) => {
+    await promisify(client.shutdown)(new Empty());
+    /*return new Promise((resolve, reject) => {
       client.shutdown(new Empty(), (err, _res: Empty) => {
         if (err) {
           return reject(err);
@@ -35,12 +37,13 @@ export default class GRPCClientSidecar implements IClientSidecar {
 
         return resolve();
       });
-    });
+    });*/
   }
 
   static async isStarted(client: GRPCClient): Promise<boolean> {
     const callClient = await client.getClient(false);
 
+    //await promisify(callClient.getMetadata)(new Empty());
     return new Promise((resolve, _reject) => {
       try {
         callClient.getMetadata(new Empty(), (err, _res: GetMetadataResponse) => {


### PR DESCRIPTION
# Description

I replaced callbacks in the gRPC client implementation with their promise equivalent.

It uses promisify. I considered wrapping the client itself, but I couldn't do it in a truly type-safe way.


## Issue reference

#483 
 
## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [NA] Created/updated tests
- [NA] Extended the documentation

Ps: Sorry for the delay, I kind of forgot that this issue existed to be honest.