### PR TITLE
docs: adding doc to inform of github dapr bot commands available in the repo

### DIFF
--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -127,3 +127,4 @@ The `daprdocs` directory contains the markdown files that are rendered into the 
 
 - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
 - All files and directories should be prefixed with `js-` to ensure all file/directory names are globally unique across all Dapr documentation.
+

--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -127,4 +127,3 @@ The `daprdocs` directory contains the markdown files that are rendered into the 
 
 - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
 - All files and directories should be prefixed with `js-` to ensure all file/directory names are globally unique across all Dapr documentation.
-

--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -105,7 +105,7 @@ subject is clear and precise enough that users will know what change by just loo
 
 ## Github Dapr Bot Commands
 
-Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users.
 
 ## Coding Rules
 

--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -103,6 +103,9 @@ Try to keep the first commit line short. This is harder to do using this commit 
 concise and if you need more space, you can use the commit body. Try to make sure that the commit
 subject is clear and precise enough that users will know what change by just looking at the changelog.
 
+## Github Dapr Bot Commands
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users
+
 ## Coding Rules
 
 To ensure consistency throughout the source code, keep these rules in mind as you are working:
@@ -124,3 +127,4 @@ The `daprdocs` directory contains the markdown files that are rendered into the 
 
 - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
 - All files and directories should be prefixed with `js-` to ensure all file/directory names are globally unique across all Dapr documentation.
+

--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -104,6 +104,7 @@ concise and if you need more space, you can use the commit body. Try to make sur
 subject is clear and precise enough that users will know what change by just looking at the changelog.
 
 ## Github Dapr Bot Commands
+
 Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users
 
 ## Coding Rules
@@ -127,4 +128,3 @@ The `daprdocs` directory contains the markdown files that are rendered into the 
 
 - All rules in the [docs guide]({{< ref contributing-docs.md >}}) should be followed in addition to these.
 - All files and directories should be prefixed with `js-` to ensure all file/directory names are globally unique across all Dapr documentation.
-

--- a/daprdocs/content/en/js-sdk-contributing/js-contributing.md
+++ b/daprdocs/content/en/js-sdk-contributing/js-contributing.md
@@ -104,7 +104,7 @@ concise and if you need more space, you can use the commit body. Try to make sur
 subject is clear and precise enough that users will know what change by just looking at the changelog.
 
 ## Github Dapr Bot Commands
-Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users
+Checkout the [daprbot documentation](https://docs.dapr.io/contributing/daprbot/) for Github commands you can run in this repo for common tasks. For example, you can run the `/assign` (as a comment on an issue) to assign issues to a user or group of users
 
 ## Coding Rules
 


### PR DESCRIPTION
# Description

Informs users about the Github dapr bot commands available in the repo with doc link. 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #525

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [x] Extended the documentation
