### PR TITLE
If an api token is not passed in the constructor, check the env variable

### DIFF
--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -79,7 +79,11 @@ npm run start:dapr-grpc
 
 ### Environment Variables
 
-You can use the `DAPR_HTTP_ENDPOINT` and `DAPR_GRPC_ENDPOINT` environment variables to set the Dapr Sidecar's HTTP and gRPC endpoints respectively. When these variables are set, the `daprHost` and `daprPort` don't have to be passed to the constructor, the client will parse them automatically out of the provided endpoints.
+##### Dapr Sidecar Endpoints
+You can use the `DAPR_HTTP_ENDPOINT` and `DAPR_GRPC_ENDPOINT` environment variables to set the Dapr
+Sidecar's HTTP and gRPC endpoints respectively. When these variables are set, the `daprHost`
+and `daprPort` don't have to be set in the options argument of the constructor, the client will parse them automatically
+out of the provided endpoints.
 
 ```typescript
 import { DaprClient, CommunicationProtocol } from "@dapr/dapr";
@@ -91,7 +95,13 @@ const client = new DaprClient();
 const client = new DaprClient({ communicationProtocol: CommunicationProtocol.GRPC });
 ```
 
-If the environment variables are set, but `daprHost` and `daprPort` values are passed to the constructor, the latter will take precedence over the environment variables.
+If the environment variables are set, but `daprHost` and `daprPort` values are passed to the
+constructor, the latter will take precedence over the environment variables.
+
+##### Dapr API Token
+You can use the `DAPR_API_TOKEN` environment variable to set the Dapr API token. When this variable
+is set, the `daprApiToken` doesn't have to be set in the options argument of the constructor,
+the client will get it automatically.
 
 ## General
 

--- a/daprdocs/content/en/js-sdk-docs/js-client/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-client/_index.md
@@ -80,6 +80,7 @@ npm run start:dapr-grpc
 ### Environment Variables
 
 ##### Dapr Sidecar Endpoints
+
 You can use the `DAPR_HTTP_ENDPOINT` and `DAPR_GRPC_ENDPOINT` environment variables to set the Dapr
 Sidecar's HTTP and gRPC endpoints respectively. When these variables are set, the `daprHost`
 and `daprPort` don't have to be set in the options argument of the constructor, the client will parse them automatically
@@ -99,6 +100,7 @@ If the environment variables are set, but `daprHost` and `daprPort` values are p
 constructor, the latter will take precedence over the environment variables.
 
 ##### Dapr API Token
+
 You can use the `DAPR_API_TOKEN` environment variable to set the Dapr API token. When this variable
 is set, the `daprApiToken` doesn't have to be set in the options argument of the constructor,
 the client will get it automatically.

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -292,7 +292,7 @@ export function getClientOptions(
     isKeepAlive: clientOptions?.isKeepAlive,
     logger: clientOptions?.logger ?? defaultLoggerOptions,
     actor: clientOptions?.actor,
-    daprApiToken: clientOptions?.daprApiToken,
+    daprApiToken: clientOptions?.daprApiToken ?? process.env.DAPR_API_TOKEN,
     maxBodySizeMb: clientOptions?.maxBodySizeMb,
   };
 }

--- a/src/utils/Client.util.ts
+++ b/src/utils/Client.util.ts
@@ -292,7 +292,7 @@ export function getClientOptions(
     isKeepAlive: clientOptions?.isKeepAlive,
     logger: clientOptions?.logger ?? defaultLoggerOptions,
     actor: clientOptions?.actor,
-    daprApiToken: clientOptions?.daprApiToken ?? process.env.DAPR_API_TOKEN,
+    daprApiToken: clientOptions?.daprApiToken ?? Settings.getDefaultApiToken(),
     maxBodySizeMb: clientOptions?.maxBodySizeMb,
   };
 }

--- a/src/utils/Settings.util.ts
+++ b/src/utils/Settings.util.ts
@@ -15,6 +15,7 @@ import CommunicationProtocolEnum from "../enum/CommunicationProtocol.enum";
 
 export class Settings {
   private static readonly defaultAppId: string = "my-dapr-app";
+  private static readonly defaultApiToken = undefined;
   private static readonly defaultHost: string = "127.0.0.1";
   private static readonly defaultHttpAppPort: string = "3000";
   private static readonly defaultHttpPort: string = "3500";
@@ -49,6 +50,10 @@ export class Settings {
 
   static getAppId(): string {
     return process.env.APP_ID ?? Settings.defaultAppId;
+  }
+
+  static getDefaultApiToken() {
+    return process.env.DAPR_API_TOKEN || Settings.defaultApiToken;
   }
 
   static getDefaultHost(): string {

--- a/test/unit/utils/Client.util.test.ts
+++ b/test/unit/utils/Client.util.test.ts
@@ -368,7 +368,7 @@ describe("Client.util", () => {
       expect(options.daprApiToken).toEqual("token");
     });
 
-    it("returns correct Dapr Client Options when token provided in anv variable", () => {
+    it("returns correct Dapr Client Options when token provided in env variable", () => {
       const oldToken = process.env.DAPR_API_TOKEN
       process.env.DAPR_API_TOKEN = "envtoken";
       const options = getClientOptions(undefined, CommunicationProtocolEnum.HTTP, undefined);
@@ -376,7 +376,7 @@ describe("Client.util", () => {
       process.env.DAPR_API_TOKEN = oldToken;
     });
 
-    it("returns correct Dapr Client Options when token provided both in constructor and in anv variable", () => {
+    it("returns correct Dapr Client Options when token provided both in constructor and in env variable", () => {
       process.env.DAPR_API_TOKEN = "envtoken";
 
       const inOptions: Partial<DaprClientOptions> = {

--- a/test/unit/utils/Client.util.test.ts
+++ b/test/unit/utils/Client.util.test.ts
@@ -359,7 +359,6 @@ describe("Client.util", () => {
       expect(options).toEqual(expectedOptions);
     });
 
-
     it("returns correct Dapr Client Options when token provided in constructor", () => {
       const inOptions: Partial<DaprClientOptions> = {
         daprApiToken: "token",
@@ -369,7 +368,7 @@ describe("Client.util", () => {
     });
 
     it("returns correct Dapr Client Options when token provided in env variable", () => {
-      const oldToken = process.env.DAPR_API_TOKEN
+      const oldToken = process.env.DAPR_API_TOKEN;
       process.env.DAPR_API_TOKEN = "envtoken";
       const options = getClientOptions(undefined, CommunicationProtocolEnum.HTTP, undefined);
       expect(options.daprApiToken).toEqual("envtoken");

--- a/test/unit/utils/Client.util.test.ts
+++ b/test/unit/utils/Client.util.test.ts
@@ -359,6 +359,36 @@ describe("Client.util", () => {
       expect(options).toEqual(expectedOptions);
     });
 
+
+    it("returns correct Dapr Client Options when token provided in constructor", () => {
+      const inOptions: Partial<DaprClientOptions> = {
+        daprApiToken: "token",
+      };
+      const options = getClientOptions(inOptions, CommunicationProtocolEnum.HTTP, undefined);
+      expect(options.daprApiToken).toEqual("token");
+    });
+
+    it("returns correct Dapr Client Options when token provided in anv variable", () => {
+      const oldToken = process.env.DAPR_API_TOKEN
+      process.env.DAPR_API_TOKEN = "envtoken";
+      const options = getClientOptions(undefined, CommunicationProtocolEnum.HTTP, undefined);
+      expect(options.daprApiToken).toEqual("envtoken");
+      process.env.DAPR_API_TOKEN = oldToken;
+    });
+
+    it("returns correct Dapr Client Options when token provided both in constructor and in anv variable", () => {
+      process.env.DAPR_API_TOKEN = "envtoken";
+
+      const inOptions: Partial<DaprClientOptions> = {
+        daprApiToken: "token",
+      };
+      const options = getClientOptions(inOptions, CommunicationProtocolEnum.HTTP, undefined);
+
+      expect(options.daprApiToken).toEqual("token");
+
+      delete process.env.DAPR_API_TOKEN;
+    });
+
     it("returns correct Dapr Client Options when undefined options provided", () => {
       const options = getClientOptions(undefined, CommunicationProtocolEnum.GRPC, undefined);
       const expectedOptions: Partial<DaprClientOptions> = {


### PR DESCRIPTION
# Description

Adds the possibility to get an api token from the standard environment variable, as described in this proposal https://github.com/dapr/proposals/blob/main/0010-S-unified-api-token-env-variable.md

## Issue reference
https://github.com/dapr/js-sdk/issues/547

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [X] Extended the documentation
