### PR TITLE
Fix e2e test http actortest

### DIFF
--- a/test/e2e/http/actors.test.ts
+++ b/test/e2e/http/actors.test.ts
@@ -113,7 +113,7 @@ describe("http/actors", () => {
 
       const config = JSON.parse(await res.text());
 
-      expect(config.entities.length).toBe(9);
+      expect(config.entities.length).toBe(11);
       expect(config.actorIdleTimeout).toBe("1h");
       expect(config.actorScanInterval).toBe("30s");
       expect(config.drainOngoingCallTimeout).toBe("1m");

--- a/test/e2e/http/actors.test.ts
+++ b/test/e2e/http/actors.test.ts
@@ -179,15 +179,19 @@ describe("http/actors", () => {
     it("should register actors correctly", async () => {
       const actors = await server.actor.getRegisteredActors();
 
-      expect(actors.length).toEqual(9);
+      expect(actors.length).toEqual(11);
 
       expect(actors).toContain(DemoActorCounterImpl.name);
       expect(actors).toContain(DemoActorSayImpl.name);
       expect(actors).toContain(DemoActorReminderImpl.name);
+      expect(actors).toContain(DemoActorReminder2Impl.name);
+      expect(actors).toContain(DemoActorReminderOnceImpl.name);
       expect(actors).toContain(DemoActorTimerImpl.name);
+      expect(actors).toContain(DemoActorTimerOnceImpl.name);
       expect(actors).toContain(DemoActorActivateImpl.name);
       expect(actors).toContain(DemoActorTimerTtlImpl.name);
       expect(actors).toContain(DemoActorReminderTtlImpl.name);
+      expect(actors).toContain(DemoActorDeleteStateImpl.name);
     });
 
     it("should be able to invoke an actor through a text message", async () => {


### PR DESCRIPTION
# Description
it fails due to the following log
```
== APP ==   ● http/actors › configuration › actor configuration endpoint should contain the correct parameters
== APP == 
== APP ==     expect(received).toBe(expected) // Object.is equality
== APP == 
== APP ==     Expected: 9
== APP ==     Received: 11
== APP == 
== APP ==       114 |       const config = JSON.parse(await res.text());
== APP ==       115 |
== APP ==     > 116 |       expect(config.entities.length).toBe(9);
== APP ==           |                                      ^
== APP ==       117 |       expect(config.actorIdleTimeout).toBe("1h");
== APP ==       118 |       expect(config.actorScanInterval).toBe("30s");
== APP ==       119 |       expect(config.drainOngoingCallTimeout).toBe("1m");
== APP == 
== APP ==       at test/e2e/http/actors.test.ts:116:38
== APP ==       at fulfilled (test/e2e/http/actors.test.ts:40:58)
```

This is because two actors were newly registered in pr #536. For more details could refer to this [link](https://github.com/dapr/js-sdk/commit/0fb83c1fda6a47e3f9a5753d24e6b0dcfe311985) .
