### PR TITLE
fix e2e test common/server/server.test.ts

### DIFF
--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -138,7 +138,8 @@ describe("common/server", () => {
     });
 
     await setupPubSubSubscriptions();
-    // Sleep for 2 seconds to allow all subscriptions to be registered
+    // Sleep to make the tests less flaky.
+    // TODO: https://github.com/dapr/js-sdk/issues/560
     await NodeJSUtil.sleep(2000);
 
     await httpServer.start();

--- a/test/e2e/common/server.test.ts
+++ b/test/e2e/common/server.test.ts
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import { CommunicationProtocolEnum, DaprServer, DaprPubSubStatusEnum } from "../../../src";
+import * as NodeJSUtil from "../../../src/utils/NodeJS.util";
 
 const serverHost = "127.0.0.1";
 const serverGrpcPort = "50001";
@@ -48,6 +49,9 @@ const bulkSubscribeTopic = "bulk-subscribe-topic";
 const bulkSubscribeClodEventTopic = "bulk-subscribe-ce-topic";
 const bulkSubscribeCloudEventToRawPayloadTopic = "bulk-subscribe-ce-rp-topic";
 const bulkSubscribeRawPayloadToClodEventTopic = "bulk-subscribe-rp-ce-topic";
+
+// Set timeout to 10s for all tests
+jest.setTimeout(10000);
 
 describe("common/server", () => {
   let httpServer: DaprServer;
@@ -134,9 +138,13 @@ describe("common/server", () => {
     });
 
     await setupPubSubSubscriptions();
+    // Sleep for 2 seconds to allow all subscriptions to be registered
+    await NodeJSUtil.sleep(2000);
 
     await httpServer.start();
     await grpcServer.start();
+    // Sleep for 2 seconds to get servers ready
+    await NodeJSUtil.sleep(2000);
   });
 
   beforeEach(() => {
@@ -161,7 +169,7 @@ describe("common/server", () => {
         const res = await server.client.pubsub.publish(pubSubName, getTopic(topicWithStatusCb, protocol), "SUCCESS");
         expect(res.error).toBeUndefined();
         // Delay a bit for event to arrive
-        await new Promise((resolve, _reject) => setTimeout(resolve, 1000));
+        await new Promise((resolve, _reject) => setTimeout(resolve, 2000));
         expect(mockSubscribeStatusHandler.mock.calls.length).toBe(1);
         expect(mockSubscribeStatusHandler.mock.calls[0][1]).toEqual("SUCCESS");
         expect(mockSubscribeDeadletterHandler.mock.calls.length).toBe(0);


### PR DESCRIPTION
# Description
It fails due to the following log. For more log details refer to this [link](https://github.com/dapr/dapr/actions/runs/7017990038/job/19092429905).
```
...
  ● common/server › pubsub › grpc/should mark messages as processed successfully (SUCCESS) by-default, and the same message should not be received anymore

    expect(received).toBe(expected) // Object.is equality

    Expected: 1
    Received: 0

      163 |         // Delay a bit for event to arrive
      164 |         await new Promise((resolve, _reject) => setTimeout(resolve, 1000));
    > 165 |         expect(mockSubscribeStatusHandler.mock.calls.length).toBe(1);
          |                                                              ^
      166 |         expect(mockSubscribeStatusHandler.mock.calls[0][1]).toEqual("SUCCESS");
      167 |         expect(mockSubscribeDeadletterHandler.mock.calls.length).toBe(0);
      168 |       },

      at test/e2e/common/server.test.ts:165:62
      at fulfilled (test/e2e/common/server.test.ts:17:58)
...
```

The delay is not long enough to wait for the event to arrive. Adding more delay could be helpful. 

## Issue reference

Please refer to the the point 4 of issue [#7128](https://github.com/dapr/dapr/issues/7128) in dapr/dapr.

