### PR TITLE
Fix Configuration GRPC calls not sending metadata

### DIFF
--- a/src/implementation/Client/GRPCClient/configuration.ts
+++ b/src/implementation/Client/GRPCClient/configuration.ts
@@ -12,7 +12,6 @@ limitations under the License.
 */
 
 import GRPCClient from "./GRPCClient";
-import * as grpc from "@grpc/grpc-js";
 import {
   GetConfigurationRequest,
   GetConfigurationResponse,
@@ -38,26 +37,18 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
   }
 
   async get(storeName: string, keys: string[], metadataObj?: KeyValueType): Promise<GetConfigurationResponseResult> {
-    const metadata = new grpc.Metadata();
-
     const msg = new GetConfigurationRequest();
     msg.setStoreName(storeName);
 
     if (keys && keys.length > 0) {
       msg.setKeysList(keys.filter((i) => i !== ""));
     }
-
-    if (metadataObj) {
-      for (const [key, value] of Object.entries(metadataObj)) {
-        metadata.add(key, value);
-      }
-      addMetadataToMap(msg.getMetadataMap(), metadataObj);
-    }
+    addMetadataToMap(msg.getMetadataMap(), metadataObj);
 
     const client = await this.client.getClient();
 
     return new Promise((resolve, reject) => {
-      client.getConfiguration(msg, metadata, (err, res: GetConfigurationResponse) => {
+      client.getConfiguration(msg, (err, res: GetConfigurationResponse) => {
         if (err) {
           return reject(err);
         }
@@ -100,8 +91,6 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     keys?: string[],
     metadataObj?: KeyValueType,
   ): Promise<SubscribeConfigurationStream> {
-    const metadata = new grpc.Metadata();
-
     const msg = new SubscribeConfigurationRequest();
     msg.setStoreName(storeName);
 
@@ -110,13 +99,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     } else {
       msg.setKeysList([]);
     }
-
-    if (metadataObj) {
-      for (const [key, value] of Object.entries(metadataObj)) {
-        metadata.add(key, value);
-      }
-      addMetadataToMap(msg.getMetadataMap(), metadataObj);
-    }
+    addMetadataToMap(msg.getMetadataMap(), metadataObj);
 
     const client = await this.client.getClient();
 
@@ -124,7 +107,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
     // and will stay open as long as the client is open
     // we will thus create a set with our listeners so we don't
     // break on multi listeners
-    const stream = client.subscribeConfiguration(msg, metadata);
+    const stream = client.subscribeConfiguration(msg);
     let streamId: string;
 
     stream.on("data", async (data: SubscribeConfigurationResponse) => {

--- a/src/implementation/Client/GRPCClient/configuration.ts
+++ b/src/implementation/Client/GRPCClient/configuration.ts
@@ -28,7 +28,7 @@ import { SubscribeConfigurationResponse as SubscribeConfigurationResponseResult 
 import { SubscribeConfigurationCallback } from "../../../types/configuration/SubscribeConfigurationCallback";
 import { SubscribeConfigurationStream } from "../../../types/configuration/SubscribeConfigurationStream";
 import { ConfigurationItem } from "../../../types/configuration/ConfigurationItem";
-import { createConfigurationType } from "../../../utils/Client.util";
+import { addMetadataToMap, createConfigurationType } from "../../../utils/Client.util";
 
 export default class GRPCClientConfiguration implements IClientConfiguration {
   client: GRPCClient;
@@ -51,6 +51,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
       for (const [key, value] of Object.entries(metadataObj)) {
         metadata.add(key, value);
       }
+      addMetadataToMap(msg.getMetadataMap(), metadataObj);
     }
 
     const client = await this.client.getClient();
@@ -114,6 +115,7 @@ export default class GRPCClientConfiguration implements IClientConfiguration {
       for (const [key, value] of Object.entries(metadataObj)) {
         metadata.add(key, value);
       }
+      addMetadataToMap(msg.getMetadataMap(), metadataObj);
     }
 
     const client = await this.client.getClient();

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -363,14 +363,11 @@ describe("grpc/client", () => {
     });
 
     it("should be able to get the configuration items with metadata", async () => {
-      await client.configuration.get("config-redis", ["myconfigkey1"], {
+      const conf = await client.configuration.get("config-redis", ["myconfigkey1"], {
         hello: "world",
       });
 
-      // Disabled for now as I am unsure if Dapr returns the metadata items
-      // Java SDK: https://github.com/dapr/java-sdk/blob/06d92dafca62a6b48e74ccf939feeac7189e360f/sdk/src/test/java/io/dapr/client/DaprPreviewClientGrpcTest.java#L119
-      // ^ shows that it is not being tested, it tries but doesn't assert
-      // expect(conf.items.filter(i => i.key == "myconfigkey1")[0].metadata).toHaveProperty("hello");
+      expect(conf.items["myconfigkey1"].metadata).toHaveProperty("hello");
     });
 
     it("should be able to subscribe to configuration item changes on all keys", async () => {


### PR DESCRIPTION
# Description

When sending a request for Configurations from Azure App Config, the call would silently drop the metadata that was sent with it.  This would cause keys to be returned only if they had no labels on them when specified.

Having some unrelated errors preventing my local tests from running, though I did validate the change with the app that created this issue.  Let me know if I'm missing a spot that should also be updated, as I'm new to this codebase.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #570 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [ ] Extended the documentation
