### PR TITLE
[release-3.3] chore(release): Prepare for v3.3.0 release (#577)

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,8 +35,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOVER: 1.21
-      DAPR_CLI_VER: 1.13.0-rc.1
-      DAPR_RUNTIME_VER: 1.13.0-rc.10
+      DAPR_CLI_VER: 1.13.0
+      DAPR_RUNTIME_VER: 1.13.0
       DAPR_INSTALL_URL: https://raw.githubusercontent.com/dapr/cli/master/install/install.sh
       DAPR_CLI_REF: ""
       DAPR_REF: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dapr/dapr",
-  "version": "3.3.0-rc.1",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dapr/dapr",
-      "version": "3.3.0-rc.1",
+      "version": "3.3.0",
       "license": "ISC",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dapr/dapr",
-  "version": "3.3.0-rc.1",
+  "version": "3.3.0",
   "description": "The official Dapr (https://dapr.io) SDK for Node.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/scripts/fetch-proto.sh
+++ b/scripts/fetch-proto.sh
@@ -3,7 +3,7 @@ OS=$(echo `uname`|tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 ORG_NAME="dapr"
 REPO_NAME="dapr"
-BRANCH_NAME="v1.13.0-rc.10"
+BRANCH_NAME="v1.13.0"
 
 # Path to store output
 PATH_ROOT=$(pwd)


### PR DESCRIPTION
Update protos, update e2e pipeline, bump version

# Description

Cherry-picked from https://github.com/dapr/js-sdk/pull/577

