### PR TITLE
fix(proto): update gRPC requests to use the correct request parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:load": "jest --runInBand --detectOpenHandles",
     "test:load:http": "TEST_SECRET_1=secret_val_1 TEST_SECRET_2=secret_val_2 dapr run --app-id test-suite --app-protocol http --app-port 50001 --dapr-http-port 50000 --components-path ./test/components -- npm run test:load 'test/load'",
     "test:e2e": "jest --runInBand --detectOpenHandles",
-    "test:e2e:all": "npm run test:e2e:http; npm run test:e2e:grpc; npm run test:e2e:common; npm run test:e2e:workflow",
+    "test:e2e:all": "npm run test:e2e:http && npm run test:e2e:grpc && npm run test:e2e:common && npm run test:e2e:workflow",
     "test:e2e:grpc": "npm run test:e2e:grpc:client && npm run test:e2e:grpc:server && npm run test:e2e:grpc:clientWithApiToken",
     "test:e2e:grpc:client": "npm run prebuild && TEST_SECRET_1=secret_val_1 TEST_SECRET_2=secret_val_2 dapr run --app-id test-suite --app-protocol grpc --app-port 50001 --dapr-grpc-port 50000 --components-path ./test/components -- jest --runInBand --detectOpenHandles --testMatch [ '**/test/e2e/grpc/*client.test.ts' ]",
     "test:e2e:grpc:clientWithApiToken": "npm run prebuild && TEST_SECRET_1=secret_val_1 TEST_SECRET_2=secret_val_2 DAPR_API_TOKEN=test dapr run --app-id test-suite --app-protocol grpc --app-port 50001 --dapr-grpc-port 50000 --components-path ./test/components -- jest --runInBand --detectOpenHandles --testMatch [ '**/test/e2e/grpc/clientWithApiToken.test.ts' ]",

--- a/src/actors/client/ActorClient/ActorClientGRPC.ts
+++ b/src/actors/client/ActorClient/ActorClientGRPC.ts
@@ -11,7 +11,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { Any } from "google-protobuf/google/protobuf/any_pb";
 import {
   ExecuteActorStateTransactionRequest,

--- a/src/actors/client/ActorClient/ActorClientGRPC.ts
+++ b/src/actors/client/ActorClient/ActorClientGRPC.ts
@@ -17,6 +17,7 @@ import {
   ExecuteActorStateTransactionRequest,
   GetActorStateRequest,
   GetActorStateResponse,
+  GetMetadataRequest,
   GetMetadataResponse,
   InvokeActorRequest,
   InvokeActorResponse,
@@ -279,7 +280,7 @@ export default class ActorClientGRPC implements IClientActor {
     const client = await this.client.getClient();
 
     return new Promise((resolve, reject) => {
-      client.getMetadata(new Empty(), (err, res: GetMetadataResponse) => {
+      client.getMetadata(new GetMetadataRequest(), (err, res: GetMetadataResponse) => {
         if (err) {
           return reject(err);
         }

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -29,7 +29,7 @@ export default class GRPCClient implements IClient {
   private isInitialized: boolean;
   private readonly client: GrpcDaprClient;
   private readonly clientCredentials: grpc.ChannelCredentials;
-  public readonly logger: Logger;
+  private readonly logger: Logger;
   private readonly grpcClientOptions: Partial<grpc.ClientOptions>;
   private daprEndpoint: GrpcEndpoint;
 

--- a/src/implementation/Client/GRPCClient/GRPCClient.ts
+++ b/src/implementation/Client/GRPCClient/GRPCClient.ts
@@ -29,7 +29,7 @@ export default class GRPCClient implements IClient {
   private isInitialized: boolean;
   private readonly client: GrpcDaprClient;
   private readonly clientCredentials: grpc.ChannelCredentials;
-  private readonly logger: Logger;
+  public readonly logger: Logger;
   private readonly grpcClientOptions: Partial<grpc.ClientOptions>;
   private daprEndpoint: GrpcEndpoint;
 

--- a/src/implementation/Client/GRPCClient/health.ts
+++ b/src/implementation/Client/GRPCClient/health.ts
@@ -14,7 +14,6 @@ limitations under the License.
 import GRPCClient from "./GRPCClient";
 import IClientHealth from "../../../interfaces/Client/IClientHealth";
 import { GetMetadataRequest, GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
 // https://docs.dapr.io/reference/api/health_api/
 export default class GRPCClientHealth implements IClientHealth {

--- a/src/implementation/Client/GRPCClient/health.ts
+++ b/src/implementation/Client/GRPCClient/health.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import GRPCClient from "./GRPCClient";
 import IClientHealth from "../../../interfaces/Client/IClientHealth";
-import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+import { GetMetadataRequest, GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
 // https://docs.dapr.io/reference/api/health_api/
@@ -30,7 +30,7 @@ export default class GRPCClientHealth implements IClientHealth {
 
     return new Promise((resolve, _reject) => {
       try {
-        client.getMetadata(new Empty(), (err, _res: GetMetadataResponse) => {
+        client.getMetadata(new GetMetadataRequest(), (err, _res: GetMetadataResponse) => {
           if (err) {
             return resolve(false);
           }

--- a/src/implementation/Client/GRPCClient/metadata.ts
+++ b/src/implementation/Client/GRPCClient/metadata.ts
@@ -12,7 +12,11 @@ limitations under the License.
 */
 
 import GRPCClient from "./GRPCClient";
-import { GetMetadataRequest, GetMetadataResponse, SetMetadataRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+import {
+  GetMetadataRequest,
+  GetMetadataResponse,
+  SetMetadataRequest,
+} from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import IClientMetadata from "../../../interfaces/Client/IClientMetadata";
 import { GetMetadataResponse as GetMetadataResponseResult } from "../../../types/metadata/GetMetadataResponse";

--- a/src/implementation/Client/GRPCClient/metadata.ts
+++ b/src/implementation/Client/GRPCClient/metadata.ts
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import GRPCClient from "./GRPCClient";
-import { GetMetadataResponse, SetMetadataRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+import { GetMetadataRequest, GetMetadataResponse, SetMetadataRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import IClientMetadata from "../../../interfaces/Client/IClientMetadata";
 import { GetMetadataResponse as GetMetadataResponseResult } from "../../../types/metadata/GetMetadataResponse";
@@ -30,7 +30,7 @@ export default class GRPCClientMetadata implements IClientMetadata {
     const client = await this.client.getClient();
 
     return new Promise((resolve, reject) => {
-      client.getMetadata(new Empty(), (err, res: GetMetadataResponse) => {
+      client.getMetadata(new GetMetadataRequest(), (err, res: GetMetadataResponse) => {
         if (err) {
           return reject(err);
         }

--- a/src/implementation/Client/GRPCClient/sidecar.ts
+++ b/src/implementation/Client/GRPCClient/sidecar.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import GRPCClient from "./GRPCClient";
 import IClientSidecar from "../../../interfaces/Client/IClientSidecar";
-import { GetMetadataRequest, GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+import { GetMetadataRequest, GetMetadataResponse, ShutdownRequest } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
 // https://docs.dapr.io/reference/api/secrets_api/
@@ -28,7 +28,7 @@ export default class GRPCClientSidecar implements IClientSidecar {
     const client = await this.client.getClient();
 
     return new Promise((resolve, reject) => {
-      client.shutdown(new Empty(), (err, _res: Empty) => {
+      client.shutdown(new ShutdownRequest(), (err, _res: Empty) => {
         if (err) {
           return reject(err);
         }

--- a/src/implementation/Client/GRPCClient/sidecar.ts
+++ b/src/implementation/Client/GRPCClient/sidecar.ts
@@ -13,7 +13,7 @@ limitations under the License.
 
 import GRPCClient from "./GRPCClient";
 import IClientSidecar from "../../../interfaces/Client/IClientSidecar";
-import { GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
+import { GetMetadataRequest, GetMetadataResponse } from "../../../proto/dapr/proto/runtime/v1/dapr_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 
 // https://docs.dapr.io/reference/api/secrets_api/
@@ -43,7 +43,7 @@ export default class GRPCClientSidecar implements IClientSidecar {
 
     return new Promise((resolve, _reject) => {
       try {
-        callClient.getMetadata(new Empty(), (err, _res: GetMetadataResponse) => {
+        callClient.getMetadata(new GetMetadataRequest(), (err, _res: GetMetadataResponse) => {
           if (err) {
             return resolve(false);
           }

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -362,7 +362,7 @@ describe("grpc/client", () => {
       expect(config.items["myconfigkey3"].value == "key3_initialvalue");
     });
 
-    // todo: enable this once we have a component to test this with. 
+    // todo: enable this once we have a component to test this with.
     // Redis does not support metadata, PG and Azure App Config do.
     // it("should be able to get the configuration items with metadata", async () => {
     //   const conf = await client.configuration.get("config-redis", ["myconfigkey1"], {

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -20,7 +20,6 @@ import { CommunicationProtocolEnum, DaprClient, LogLevel } from "../../../src";
 import { SubscribeConfigurationResponse } from "../../../src/types/configuration/SubscribeConfigurationResponse";
 import * as DockerUtils from "../../utils/DockerUtil";
 import { DaprClient as DaprClientGrpc } from "../../../src/proto/dapr/proto/runtime/v1/dapr_grpc_pb";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
 import { GetMetadataRequest } from "../../../src/proto/dapr/proto/runtime/v1/dapr_pb";
 

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -22,6 +22,7 @@ import * as DockerUtils from "../../utils/DockerUtil";
 import { DaprClient as DaprClientGrpc } from "../../../src/proto/dapr/proto/runtime/v1/dapr_grpc_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
+import { GetMetadataRequest } from "../../../src/proto/dapr/proto/runtime/v1/dapr_pb";
 
 const daprHost = "localhost";
 const daprPort = "50000"; // Dapr Sidecar Port of this Example Server
@@ -76,7 +77,7 @@ describe("grpc/client", () => {
         interceptors: [mockInterceptor],
       });
 
-      await new Promise((resolve) => clientProxy.getMetadata(new Empty(), resolve));
+      await new Promise((resolve) => clientProxy.getMetadata(new GetMetadataRequest(), resolve));
 
       expect(mockInterceptor.mock.calls.length).toBe(1);
       expect(mockMetadataRes.get("dapr-app-id")[0]).toBe("test-suite");
@@ -104,7 +105,7 @@ describe("grpc/client", () => {
         interceptors: [mockInterceptor],
       });
 
-      await new Promise((resolve) => clientProxy.getMetadata(new Empty(), resolve));
+      await new Promise((resolve) => clientProxy.getMetadata(new GetMetadataRequest(), resolve));
 
       expect(mockInterceptor.mock.calls.length).toBe(1);
       expect(mockMetadataRes.get("dapr-app-id")[0]).toBe(process.env.APP_ID);

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -362,13 +362,13 @@ describe("grpc/client", () => {
       expect(config.items["myconfigkey3"].value == "key3_initialvalue");
     });
 
-    it("should be able to get the configuration items with metadata", async () => {
-      const conf = await client.configuration.get("config-redis", ["myconfigkey1"], {
-        hello: "world",
-      });
-
-      expect(conf.items["myconfigkey1"].metadata).toHaveProperty("hello");
-    });
+    // todo: enable this once we have a component to test this with. 
+    // Redis does not support metadata, PG and Azure App Config do.
+    // it("should be able to get the configuration items with metadata", async () => {
+    //   const conf = await client.configuration.get("config-redis", ["myconfigkey1"], {
+    //     hello: "world",
+    //   });
+    // });
 
     it("should be able to subscribe to configuration item changes on all keys", async () => {
       const m = jest.fn(async (_res: SubscribeConfigurationResponse) => {

--- a/test/e2e/grpc/clientWithApiToken.test.ts
+++ b/test/e2e/grpc/clientWithApiToken.test.ts
@@ -14,7 +14,6 @@ limitations under the License.
 import * as grpc from "@grpc/grpc-js";
 import { CommunicationProtocolEnum, DaprClient, LogLevel } from "../../../src";
 import { DaprClient as DaprClientGrpc } from "../../../src/proto/dapr/proto/runtime/v1/dapr_grpc_pb";
-import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
 import { GetMetadataRequest } from "../../../src/proto/dapr/proto/runtime/v1/dapr_pb";
 

--- a/test/e2e/grpc/clientWithApiToken.test.ts
+++ b/test/e2e/grpc/clientWithApiToken.test.ts
@@ -16,6 +16,7 @@ import { CommunicationProtocolEnum, DaprClient, LogLevel } from "../../../src";
 import { DaprClient as DaprClientGrpc } from "../../../src/proto/dapr/proto/runtime/v1/dapr_grpc_pb";
 import { Empty } from "google-protobuf/google/protobuf/empty_pb";
 import { NextCall } from "@grpc/grpc-js/build/src/client-interceptors";
+import { GetMetadataRequest } from "../../../src/proto/dapr/proto/runtime/v1/dapr_pb";
 
 const daprHost = "localhost";
 const daprPort = "50000"; // Dapr Sidecar Port of this Example Server
@@ -50,7 +51,7 @@ describe("grpc/client with api token", () => {
       interceptors: [mockInterceptor],
     });
 
-    await new Promise((resolve) => clientProxy.getMetadata(new Empty(), resolve));
+    await new Promise((resolve) => clientProxy.getMetadata(new GetMetadataRequest(), resolve));
     expect(mockMetadataRes.get("dapr-api-token")[0]).toBe("test");
   });
 });


### PR DESCRIPTION
# Description

Some protos were updated in https://github.com/dapr/dapr/commit/4d4c8b937b63fc5303a2a1dc90eb966c500350a5, which were not changed in the SDK. Two problems, 
(1) no compile time errors
(2) our e2e tests were ... not reporting failure! 🤦🏻 

This PR:
(1) fixes the two specific requests that had changed in the proto - `getMetadata` and `shutdown`
(2) fixes the NPM script which was using `;` instead of `&&` for e2e tests (https://unix.stackexchange.com/questions/187145/whats-the-difference-between-semicolon-and-double-ampersand)
(3) removes a test introduced in https://github.com/dapr/js-sdk/pull/571, which won't work with Redis. It need Postgres/Azure app config.

## Issue reference

Please reference the issue this PR will close: #580

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [ ] Extended the documentation
