### PR TITLE
Do not log options in HTTPServer to prevent circular reference

### DIFF
--- a/src/implementation/Server/HTTPServer/HTTPServer.ts
+++ b/src/implementation/Server/HTTPServer/HTTPServer.ts
@@ -46,8 +46,6 @@ export default class HTTPServer implements IServer {
 
     this.isInitialized = false;
 
-    this.logger.debug(`Configured HTTPServer Options: ${JSON.stringify(options)}`);
-
     this.server = options.serverHttp ?? express();
     this.server.use(
       bodyParser.text({


### PR DESCRIPTION
# Description

Having a debug log with options was causing a circular reference while using HTTP Server (see attached issue). This PR simply removes the logs and fixes it.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #488

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
