### PR TITLE
fix: Remove broken image links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,6 @@ npm install --save @dapr/dapr-dev
 
 Visit [https://docs.dapr.io/developing-applications/sdks/js/](https://docs.dapr.io/developing-applications/sdks/js/) to view the full documentation.
 
-## Who is using Dapr?
-
-Dapr is used by the world's leading companies.
-
-<div align="center">               
-    <img src="https://dapr.io/images/bosch.png" width="100px">      
-    <img src="https://dapr.io/images/zeiss.png" width="100px">        
-    <img src="https://dapr.io/images/alibaba.png" width="100px">       
-    <img src="https://dapr.io/images/ignition-group.png" width="100px">      
-    <img src="https://dapr.io/images/roadwork.png" width="100px">     
-    <img src="https://dapr.io/images/autonavi.png" width="100px">     
-    <img src="https://dapr.io/images/legentic.png" width="100px">      
-    <img src="https://dapr.io/images/man-group.png" width="100px">
-</div>
-
-View the main site [https://dapr.io/](https://dapr.io/) to learn more.
-
 ## Community
 
 There are multiple ways to get involved with the SDK community, please see [wiki/Community-engagement](https://github.com/dapr/js-sdk/wiki/Community-engagement) for more information.


### PR DESCRIPTION
# Description

Removes the Who is using Dapr section from this SDK documentation. It's better to maintain this in one place unless it is specifically listing users of this SDK.

 By the way, the missing images were moved to /casestudy, for example:

![](https://dapr.io/images/casestudy/case-study-bosch.png)


## Issue reference

Fixes: #598

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Extended the documentation
