### PR TITLE
Fixes class of canceled on client issues

### DIFF
--- a/examples/workflow/authoring/README.md
+++ b/examples/workflow/authoring/README.md
@@ -7,6 +7,7 @@
 ```bash
 # Install
 npm install
+npm install --save-dev @types/readline-sync
 
 # Run the example
 npm run start:dapr:activity-sequence

--- a/examples/workflow/authoring/src/activity-sequence.ts
+++ b/examples/workflow/authoring/src/activity-sequence.ts
@@ -13,15 +13,17 @@ limitations under the License.
 
 import { DaprWorkflowClient, WorkflowActivityContext, WorkflowContext, WorkflowRuntime, TWorkflow } from "@dapr/dapr";
 
+const daprHost = "localhost";
+const daprPort = "50001";
+const workflowRuntime = new WorkflowRuntime({
+  daprHost,
+  daprPort,
+});
+
 async function start() {
   // Update the gRPC client and worker to use a local address and port
-  const daprHost = "localhost";
-  const daprPort = "50001";
+
   const workflowClient = new DaprWorkflowClient({
-    daprHost,
-    daprPort,
-  });
-  const workflowRuntime = new WorkflowRuntime({
     daprHost,
     daprPort,
   });
@@ -66,12 +68,15 @@ async function start() {
     console.error("Error scheduling or waiting for orchestration:", error);
   }
 
-  await workflowRuntime.stop();
   await workflowClient.stop();
 
   // stop the dapr side car
   process.exit(0);
 }
+
+process.on('SIGTERM', () => {
+  workflowRuntime.stop();
+})
 
 start().catch((e) => {
   console.error(e);

--- a/examples/workflow/authoring/src/fanout-fanin.ts
+++ b/examples/workflow/authoring/src/fanout-fanin.ts
@@ -20,16 +20,17 @@ import {
   TWorkflow,
 } from "@dapr/dapr";
 
+const daprHost = "localhost";
+const daprPort = "50001";
+const workflowRuntime = new WorkflowRuntime({
+  daprHost,
+  daprPort,
+});
+
 // Wrap the entire code in an immediately-invoked async function
 async function start() {
   // Update the gRPC client and worker to use a local address and port
-  const daprHost = "localhost";
-  const daprPort = "50001";
   const workflowClient = new DaprWorkflowClient({
-    daprHost,
-    daprPort,
-  });
-  const workflowRuntime = new WorkflowRuntime({
     daprHost,
     daprPort,
   });
@@ -99,13 +100,16 @@ async function start() {
     console.error("Error scheduling or waiting for orchestration:", error);
   }
 
-  // stop worker and client
-  await workflowRuntime.stop();
+  // stop client
   await workflowClient.stop();
 
   // stop the dapr side car
   process.exit(0);
 }
+
+process.on('SIGTERM', () => {
+  workflowRuntime.stop();
+})
 
 start().catch((e) => {
   console.error(e);

--- a/examples/workflow/authoring/src/human-interaction.ts
+++ b/examples/workflow/authoring/src/human-interaction.ts
@@ -21,6 +21,13 @@ import {
 } from "@dapr/dapr";
 import * as readlineSync from "readline-sync";
 
+const daprHost = "localhost";
+const daprPort = "50001";
+const workflowRuntime = new WorkflowRuntime({
+  daprHost,
+  daprPort,
+});
+
 // Wrap the entire code in an immediately-invoked async function
 async function start() {
   class Order {
@@ -39,13 +46,7 @@ async function start() {
   }
 
   // Update the gRPC client and worker to use a local address and port
-  const daprHost = "localhost";
-  const daprPort = "50001";
   const workflowClient = new DaprWorkflowClient({
-    daprHost,
-    daprPort,
-  });
-  const workflowRuntime = new WorkflowRuntime({
     daprHost,
     daprPort,
   });
@@ -122,8 +123,7 @@ async function start() {
     console.error("Error scheduling or waiting for orchestration:", error);
   }
 
-  // stop worker and client
-  await workflowRuntime.stop();
+  // stop client
   await workflowClient.stop();
 
   // stop the dapr side car
@@ -138,6 +138,10 @@ async function promptForApproval(approver: string, workflowClient: DaprWorkflowC
     return "Order rejected";
   }
 }
+
+process.on('SIGTERM', () => {
+  workflowRuntime.stop();
+})
 
 start().catch((e) => {
   console.error(e);


### PR DESCRIPTION
# Description

This fixes #595 and class of `canceled on client` errors seen in the workflow API examples.

I observed that:
- workflowRuntime.stop() is being called in the start() method

A fixed I used is to:
- move workflowRuntime.stop() to a process on SIGTERM function/handler
```javascript
process.on('SIGTERM', () => {
  workflowRuntime.stop();
})
```
- move the declarations of workflowRuntime out of start and into the file scope, along with daprHost and daprPort so they are all visible to the new process.on SIGTERM handler


## Issue reference


Please reference the issue this PR will close: #595

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Extended the documentation
