### PR TITLE
Pin google-protobuf to non-buggy version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node-fetch": "^2.6.2",
         "body-parser": "^1.19.0",
         "express": "^4.18.2",
-        "google-protobuf": "^3.18.0",
+        "google-protobuf": "^3.18.0 <3.21.4",
         "http-terminator": "^3.2.0",
         "node-fetch": "^2.6.7"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/node-fetch": "^2.6.2",
     "body-parser": "^1.19.0",
     "express": "^4.18.2",
-    "google-protobuf": "^3.18.0",
+    "google-protobuf": "^3.18.0 <3.21.4",
     "http-terminator": "^3.2.0",
     "node-fetch": "^2.6.7"
   },

--- a/test/components/secret-file.yaml
+++ b/test/components/secret-file.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright 2022 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: secret-file
+  namespace: default
+spec:
+  type: secretstores.local.file
+  version: v1
+  metadata:
+  - name: secretsFile
+    value: test/components/secrets.json

--- a/test/components/secrets.json
+++ b/test/components/secrets.json
@@ -1,0 +1,3 @@
+{
+    "TEST_SECRET_1": "secret_value_1"
+}

--- a/test/e2e/grpc/client.test.ts
+++ b/test/e2e/grpc/client.test.ts
@@ -175,6 +175,11 @@ describe("grpc/client", () => {
       const res = await client.secret.getBulk("secret-envvars");
       expect(Object.keys(res).length).toBeGreaterThan(1);
     });
+
+    it("should be able to correctly fetch the secrets in bulk from a file", async () => {
+      const res = await client.secret.getBulk("secret-file");
+      expect(Object.keys(res).length).toBeGreaterThan(0);
+    });
   });
 
   describe("crypto", () => {


### PR DESCRIPTION
# Description

`google-protobuf@3.21.4` introduces a bug that results in secrets (and possibly other data) coming back as undefined via GRPC.  This PR is a demo that adds an E2E test case and pins the `google-protobuf` version to a working version.

If you want to see the test fail, just unpin the library version and rebuild the lock file.  I was not able to narrow down where in the protobuf library the issue is due to build issues, but I created issues in this repo as a stopgap and FYI.  I figured a maintainer here may have a better insight as to where the problem lay.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [ ] Extended the documentation
