### PR TITLE
docs: fix path for getting started documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Getting Started
 
-Instantly get started by installing the Dapr JS SDK and reading the [getting started documentation](https://docs.dapr.io/developing-applications/sdks/js) or [follow one of the quickstarts](https://github.com/dapr/quickstarts)
+Instantly get started by installing the Dapr JS SDK and reading the [getting started documentation](https://docs.dapr.io/developing-applications/sdks/js/) or [follow one of the quickstarts](https://github.com/dapr/quickstarts)
 
 ```
 npm install --save @dapr/dapr


### PR DESCRIPTION
# Description

The `/` in the path makes all the difference when it comes to loading the images in the page.

Look how it looks without the `/`:
![image](https://github.com/user-attachments/assets/5b224839-1580-4939-972b-04cd976a719f)

If you look at the request that is made it's missing the `/js` in the path:
![image](https://github.com/user-attachments/assets/03fd3e4c-64e3-43d4-a8ca-6b53f5dc278c)


With the `/`:
![image](https://github.com/user-attachments/assets/d53b0f90-efa5-4e50-bc86-979ea0f9c575)

The network request:
![image](https://github.com/user-attachments/assets/9b0083da-686b-41d7-b17e-efa40f62a8fb)


## Issue reference

No issue referenced.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
