### PR TITLE
[docs] Remove beta from JS SDK workflow docs

### DIFF
--- a/daprdocs/content/en/js-sdk-docs/js-workflow/_index.md
+++ b/daprdocs/content/en/js-sdk-docs/js-workflow/_index.md
@@ -6,10 +6,6 @@ weight: 20000
 description: How to get up and running with workflows using the Dapr JavaScript SDK
 ---
 
-{{% alert title="Note" color="primary" %}}
-Dapr Workflow is currently in beta. [See known limitations for {{% dapr-latest-version cli="true" %}}]({{< ref "workflow-overview.md#limitations" >}}).
-{{% /alert %}}
-
 Let’s create a Dapr workflow and invoke it using the console. With the [provided workflow example](https://github.com/dapr/js-sdk/tree/main/examples/workflow), you will:
 
 - Execute the workflow instance using the [JavaScript workflow worker](https://github.com/dapr/js-sdk/tree/main/src/workflow/runtime/WorkflowRuntime.ts)


### PR DESCRIPTION
# Description

Remove 'beta' from JS SDK workflow docs ahead of stable release

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: dapr/docs#3870

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
