### PR TITLE
Added suspend/resume support to DaprWorkflowClient

### DIFF
--- a/src/workflow/client/DaprWorkflowClient.ts
+++ b/src/workflow/client/DaprWorkflowClient.ts
@@ -194,6 +194,23 @@ export default class DaprWorkflowClient {
   }
 
   /**
+   * This method suspends a workflow instance, halting processing of it until resumeWorkflow is used to
+   * resume the workflow.
+   * @param {string} workflowInstanceId - The unique identifier of the workflow instance to suspend.
+   */
+  public async suspendWorkflow(workflowInstanceId: string): Promise<void> {
+    return await this._innerClient.suspendOrchestration(workflowInstanceId);
+  }
+
+  /**
+   * This method resumes a workflow instance that was suspended via suspendWorkflow.
+   * @param {string} workflowInstanceId - The unique identifier of the workflow instance to resume.
+   */
+  public async resumeWorkflow(workflowInstanceId: string): Promise<void> {
+    return await this._innerClient.resumeOrchestration(workflowInstanceId);
+  }
+
+  /**
    * Closes the inner DurableTask client and shutdown the GRPC channel.
    */
   public async stop() {


### PR DESCRIPTION
# Description
It was pointed out that the `DaprWorkflowClient` implementation didn't cover the `suspendWorkflow` or `resumeWorkflow` functionality exposed on the `durabletask-js` library, so this is a small tweak that enables both.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #659 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [N/A] Created/updated tests
- [ ] Extended the documentation
