### PR TITLE
[PubSub] Renamed `lookupTopicWildcard` method to fix spelling issue

### DIFF
--- a/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
+++ b/src/implementation/Server/GRPCServer/GRPCServerImpl.ts
@@ -208,7 +208,7 @@ export default class GRPCServerImpl implements IAppCallbackServer {
       return;
     }
 
-    const [topic, route] = this.subscriptionManager.lookupTopicWilcard(pubsub, req.getTopic(), req.getPath());
+    const [topic, route] = this.subscriptionManager.lookupTopicWildcard(pubsub, req.getTopic(), req.getPath());
     if (topic == "") {
       this.logger.warn(`Topic '${topic}' has not been subscribed to pubsub '${pubsub}', ignoring event.`);
       return;
@@ -267,7 +267,7 @@ export default class GRPCServerImpl implements IAppCallbackServer {
       return;
     }
 
-    const [topic, route] = this.subscriptionManager.lookupTopicWilcard(pubsub, req.getTopic(), req.getPath());
+    const [topic, route] = this.subscriptionManager.lookupTopicWildcard(pubsub, req.getTopic(), req.getPath());
     if (topic == "") {
       this.logger.warn(`Topic '${topic}' has not been subscribed to pubsub '${pubsub}', ignoring bulk event.`);
       return;

--- a/src/pubsub/subscriptionManager.ts
+++ b/src/pubsub/subscriptionManager.ts
@@ -126,14 +126,14 @@ export class SubscriptionManager {
   }
 
   /**
-   * Lookup the topic and route for a given pubsub, topic (with wilcard support) and path.
+   * Lookup the topic and route for a given pubsub, topic (with wildcard support) and path.
    * If not found, topic is empty.
    * @param pubsub name of the pubsub component
    * @param topic name of the topic
    * @param path path from the event
    * @returns the topic and route
    */
-  public lookupTopicWilcard(pubsub: string, topic: string, path: string): [string, string] {
+  public lookupTopicWildcard(pubsub: string, topic: string, path: string): [string, string] {
     if (!this.isPubSubRegistered(pubsub)) {
       return ["", ""];
     }

--- a/test/unit/protocols/common/subscriptionManager.test.ts
+++ b/test/unit/protocols/common/subscriptionManager.test.ts
@@ -17,7 +17,7 @@ describe("subscriptionManager", () => {
   describe("lookupTopicWildcard", () => {
     it("should return an empty topic and route if the pubsub is not registered", () => {
       const sm = new SubscriptionManager();
-      const res = sm.lookupTopicWilcard("pubsub", "topic", "route");
+      const res = sm.lookupTopicWildcard("pubsub", "topic", "route");
 
       expect(res[0]).toEqual("");
       expect(res[1]).toEqual("");
@@ -27,7 +27,7 @@ describe("subscriptionManager", () => {
       const sm = new SubscriptionManager();
       sm.registerSubscription("pubsub", "topic", {});
 
-      const res = sm.lookupTopicWilcard("pubsub", "topic-undefined", "route");
+      const res = sm.lookupTopicWildcard("pubsub", "topic-undefined", "route");
 
       expect(res[0]).toEqual("");
       expect(res[1]).toEqual("");

--- a/test/unit/protocols/grpc/GRPCServerImpl.test.ts
+++ b/test/unit/protocols/grpc/GRPCServerImpl.test.ts
@@ -58,7 +58,7 @@ describe("GRPCServerImpl", () => {
       // @ts-ignore
       g.subscriptionManager = {
         isPubSubRegistered: () => true,
-        lookupTopicWilcard: () => ["", ""],
+        lookupTopicWildcard: () => ["", ""],
       };
 
       await g.onTopicEvent(
@@ -111,7 +111,7 @@ describe("GRPCServerImpl", () => {
       // @ts-ignore
       g.subscriptionManager = {
         isPubSubRegistered: () => true,
-        lookupTopicWilcard: () => ["", ""],
+        lookupTopicWildcard: () => ["", ""],
       };
 
       await g.onBulkTopicEventAlpha1(


### PR DESCRIPTION
# Description

Fixed misspelled method name.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #665 

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
