### PR TITLE
Removing dapr-client from published builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,21 +93,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # dapr-client is deprecated, but we still want to publish it for a while.
-      - name: "[dapr-client] Configure to publish to dapr-client for deprecation notice reasons"
-        run: |
-          sed -i s#"@dapr/dapr"#"dapr-client"# package.json
-          echo "This has been deprecated and will not be updated anymore, please use https://www.npmjs.com/package/@dapr/dapr" > README.md
-
-      - name: "[dapr-client] Install dependencies"
-        run: npm install
-
-      - name: "[dapr-client] Build Package"
-        run: npm run build-ci
-
-      - name: "[dapr-client] Publish to npm (dapr-client)"
-        run: npm publish build/ --access public
-
   publish-dev:
     needs: build
     if: startsWith(github.ref, 'refs/heads/main')


### PR DESCRIPTION
# Description

Removing dapr-client target from published builds as it's been marked as deprecated for a while. Now it is fully so.

In other words, DO NOT use the package [here](https://www.npmjs.com/package/dapr-client) as it will no longer be receiving new updates. Instead, use the package [here](https://www.npmjs.com/package/@dapr/dapr) going forward.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Extended the documentation
