### PR TITLE
Renaming workflow methods for consistency with other SDKs

### DIFF
--- a/src/implementation/Client/GRPCClient/workflow.ts
+++ b/src/implementation/Client/GRPCClient/workflow.ts
@@ -23,11 +23,11 @@ export default class GRPCClientWorkflow implements IClientWorkflow {
     this.client = client;
   }
 
-  get(_instanceId: string): Promise<WorkflowGetResponseType> {
+  getWorkflowState(_instanceId: string): Promise<WorkflowGetResponseType> {
     throw new GRPCNotSupportedError();
   }
 
-  start(
+  scheduleNewWorkflow(
     _workflowName: string,
     _input?: any,
     _instanceId?: string | undefined
@@ -51,7 +51,22 @@ export default class GRPCClientWorkflow implements IClientWorkflow {
     throw new GRPCNotSupportedError();
   }
 
-  raise(_instanceId: string, _eventName: string, _input?: any): Promise<any> {
+  raiseEvent(_instanceId: string, _eventName: string, _input?: any): Promise<any> {
     throw new GRPCNotSupportedError();
+  }
+
+  /** @deprecated Use {@link getWorkflowState} instead. Will be removed with the release of Dapr 1.20. */
+  get(_instanceId: string): Promise<WorkflowGetResponseType> {
+    return this.getWorkflowState(_instanceId);
+  }
+
+  /** @deprecated Use {@link scheduleNewWorkflow} instead. Will be removed with the release of Dapr 1.20. */
+  start(_workflowName: string, _input?: any, _instanceId?: string | undefined): Promise<string> {
+    return this.scheduleNewWorkflow(_workflowName, _input, _instanceId);
+  }
+
+  /** @deprecated Use {@link raiseEvent} instead. Will be removed with the release of Dapr 1.20. */
+  raise(_instanceId: string, _eventName: string, _input?: any): Promise<any> {
+    return this.raiseEvent(_instanceId, _eventName, _input);
   }
 }

--- a/src/implementation/Client/HTTPClient/workflow.ts
+++ b/src/implementation/Client/HTTPClient/workflow.ts
@@ -31,7 +31,7 @@ export default class HTTPClientWorkflow implements IClientWorkflow {
     this.logger = new Logger("HTTPClient", "Workflow", client.options.logger);
   }
 
-  async get(instanceID: string): Promise<WorkflowGetResponseType> {
+  async getWorkflowState(instanceID: string): Promise<WorkflowGetResponseType> {
     if (!instanceID) {
       throw new PropertyRequiredError("instanceID");
     }
@@ -65,7 +65,7 @@ export default class HTTPClientWorkflow implements IClientWorkflow {
     }
   }
 
-  async start(
+  async scheduleNewWorkflow(
     workflowName: string,
     input?: any,
     instanceId?: string | undefined,
@@ -106,7 +106,7 @@ export default class HTTPClientWorkflow implements IClientWorkflow {
     }
   }
 
-  async raise(
+  async raiseEvent(
     instanceId: string,
     eventName: string,
     eventData?: any,
@@ -157,6 +157,31 @@ export default class HTTPClientWorkflow implements IClientWorkflow {
 
   async purge(instanceId: string): Promise<void> {
     await this._invokeMethod(instanceId, "purge");
+  }
+
+  /** @deprecated Use {@link getWorkflowState} instead. Will be removed with the release of Dapr 1.20. */
+  async get(instanceID: string): Promise<WorkflowGetResponseType> {
+    return this.getWorkflowState(instanceID);
+  }
+
+  /** @deprecated Use {@link scheduleNewWorkflow} instead. Will be removed with the release of Dapr 1.20. */
+  async start(
+    workflowName: string,
+    input?: any,
+    instanceId?: string | undefined,
+    options: WorkflowStartOptions = {},
+  ): Promise<string> {
+    return this.scheduleNewWorkflow(workflowName, input, instanceId, options);
+  }
+
+  /** @deprecated Use {@link raiseEvent} instead. Will be removed with the release of Dapr 1.20. */
+  async raise(
+    instanceId: string,
+    eventName: string,
+    eventData?: any,
+    options: WorkflowRaiseOptions = {},
+  ): Promise<void> {
+    return this.raiseEvent(instanceId, eventName, eventData, options);
   }
 
   async _invokeMethod(instanceId: string, method: string): Promise<any> {

--- a/src/interfaces/Client/IClientWorkflow.ts
+++ b/src/interfaces/Client/IClientWorkflow.ts
@@ -18,7 +18,7 @@ export default interface IClientWorkflow {
    * Get information about a workflow instance.
    * @param instanceId The unique identifier for the workflow instance.
    */
-  get(instanceId: string): Promise<WorkflowGetResponseType>;
+  getWorkflowState(instanceId: string): Promise<WorkflowGetResponseType>;
 
   /**
    * Starts a new workflow instance.
@@ -26,7 +26,7 @@ export default interface IClientWorkflow {
    * @param input The input to pass to the workflow, should be JSON serializable.
    * @param instanceId The unique identifier for the workflow instance, if not provided one will be generated.
    */
-  start(workflowName: string, input?: any, instanceId?: string): Promise<string>;
+  scheduleNewWorkflow(workflowName: string, input?: any, instanceId?: string): Promise<string>;
 
   /**
    * Terminates a workflow instance.
@@ -57,6 +57,21 @@ export default interface IClientWorkflow {
    * @param instanceId The unique identifier for the workflow instance.
    * @param eventName The name of the event to raise.
    * @param eventData The data associated with the event, should be JSON serializable.
+   */
+  raiseEvent(instanceId: string, eventName: string, eventData?: any): Promise<void>;
+
+  /**
+   * @deprecated Use {@link getWorkflowState} instead. Will be removed with the release of Dapr 1.20.
+   */
+  get(instanceId: string): Promise<WorkflowGetResponseType>;
+
+  /**
+   * @deprecated Use {@link scheduleNewWorkflow} instead. Will be removed with the release of Dapr 1.20.
+   */
+  start(workflowName: string, input?: any, instanceId?: string): Promise<string>;
+
+  /**
+   * @deprecated Use {@link raiseEvent} instead. Will be removed with the release of Dapr 1.20.
    */
   raise(instanceId: string, eventName: string, eventData?: any): Promise<void>;
 }

--- a/test/unit/protocols/http/workflow.test.ts
+++ b/test/unit/protocols/http/workflow.test.ts
@@ -24,22 +24,22 @@ describe("workflow", () => {
   });
   const workflow = new HTTPClientWorkflow(client);
 
-  it("should throw PropertyRequiredError when instanceID variable is not provided in get method", async () => {
-    await expect(workflow.get("")).rejects.toThrow(PropertyRequiredError);
+  it("should throw PropertyRequiredError when instanceID variable is not provided in getWorkflowState method", async () => {
+    await expect(workflow.getWorkflowState("")).rejects.toThrow(PropertyRequiredError);
   });
-  it("should throw PropertyRequiredError when workflowName variable is not provided in start method", async () => {
-    await expect(workflow.start("")).rejects.toThrow(PropertyRequiredError);
+  it("should throw PropertyRequiredError when workflowName variable is not provided in scheduleNewWorkflow method", async () => {
+    await expect(workflow.scheduleNewWorkflow("")).rejects.toThrow(PropertyRequiredError);
   });
   it("should throw PropertyRequiredError when instanceID variable is not provided in _invokeMethod method", async () => {
-    await expect(workflow._invokeMethod("", "raise")).rejects.toThrow(PropertyRequiredError);
+    await expect(workflow._invokeMethod("", "raiseEvent")).rejects.toThrow(PropertyRequiredError);
   });
   it("should throw PropertyRequiredError when method variable is not provided in _invokeMethod method", async () => {
     await expect(workflow._invokeMethod(randomUUID(), "")).rejects.toThrow(PropertyRequiredError);
   });
-  it("should throw PropertyRequiredError when instanceID variable is not provided in raise method", async () => {
-    await expect(workflow.raise("", "Event")).rejects.toThrow(PropertyRequiredError);
+  it("should throw PropertyRequiredError when instanceID variable is not provided in raiseEvent method", async () => {
+    await expect(workflow.raiseEvent("", "Event")).rejects.toThrow(PropertyRequiredError);
   });
-  it("should throw PropertyRequiredError when eventName variable is not provided in raise method", async () => {
-    await expect(workflow.raise(randomUUID(), "")).rejects.toThrow(PropertyRequiredError);
+  it("should throw PropertyRequiredError when eventName variable is not provided in raiseEvent method", async () => {
+    await expect(workflow.raiseEvent(randomUUID(), "")).rejects.toThrow(PropertyRequiredError);
   });
 });


### PR DESCRIPTION
# Description

Updates to rename workflow methods for consistency with .NET SDK. Retained the original methods to use the new methods as an alias, but added a deprecation notice (will remove as part of the v1.20 runtime release). 

This PR supersedes #680 

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [ ] Extended the documentation
