### PR TITLE
docs(actors): add JSDoc for actor runtime models and state metadata

### DIFF
--- a/src/actors/ActorId.ts
+++ b/src/actors/ActorId.ts
@@ -13,9 +13,49 @@ limitations under the License.
 
 import { randomUUID } from "crypto";
 
+/**
+ * Represents the unique identity of an actor instance.
+ *
+ * ActorId encapsulates the identity semantics for actors, providing:
+ * - Explicit ID creation for deterministic actor references
+ * - Generated ID creation for cases where identity need not be specified
+ * - URL-safe serialization for transport over HTTP/REST
+ * - Stable equality semantics based on the underlying ID string
+ *
+ * Actor IDs are immutable and must be non-empty strings. They serve as the
+ * primary key for actor identity within a given actor type.
+ *
+ * @example
+ * ```typescript
+ * // Create with explicit ID
+ * const accountId = new ActorId("user-123");
+ *
+ * // Create with generated UUID
+ * const sessionId = ActorId.createRandomId();
+ *
+ * // Get string representation
+ * const idStr = accountId.getId(); // "user-123"
+ *
+ * // Get URL-safe representation (for HTTP transport)
+ * const urlSafe = accountId.getURLSafeId(); // "user-123" (or "user%20123" if spaces present)
+ * ```
+ */
 export default class ActorId {
   private readonly id: string;
 
+  /**
+   * Constructs an ActorId with an explicit identifier.
+   *
+   * @param id - A non-empty string that uniquely identifies the actor instance within its actor type.
+   *             Can contain any string data, but will be URL-encoded for HTTP transport.
+   * @throws {Error} If id is empty or falsy.
+   *
+   * @example
+   * ```typescript
+   * const accountId = new ActorId("account-abc-123");
+   * const sessionId = new ActorId("session::xyz");
+   * ```
+   */
   constructor(id: string) {
     if (!id) {
       throw new Error("ActorId cannot be empty");
@@ -23,18 +63,59 @@ export default class ActorId {
     this.id = id;
   }
 
+  /**
+   * Generates a new ActorId with a random UUID v4 identifier.
+   *
+   * Useful for scenarios where actor identity does not need to be deterministic
+   * or application-assigned.
+   *
+   * @returns A new ActorId with a randomly generated UUID string.
+   *
+   * @example
+   * ```typescript
+   * const transactionId = ActorId.createRandomId(); // e.g., "550e8400-e29b-41d4-a716-446655440000"
+   * ```
+   */
   static createRandomId(): ActorId {
     return new ActorId(randomUUID());
   }
 
+  /**
+   * Retrieves the underlying identifier string.
+   *
+   * This returns the raw ID as provided during construction, without any encoding.
+   *
+   * @returns The actor's identifier string.
+   */
   getId() {
     return this.id;
   }
 
+  /**
+   * Retrieves the URL-safe (percent-encoded) representation of this actor ID.
+   *
+   * This encoding is suitable for use in HTTP request paths and query parameters.
+   * Special characters are percent-encoded according to RFC 3986.
+   *
+   * @returns The actor ID with special characters percent-encoded.
+   *
+   * @example
+   * ```typescript
+   * const id = new ActorId("user@domain.com");
+   * id.getURLSafeId(); // "user%40domain.com"
+   * ```
+   */
   getURLSafeId() {
     return encodeURIComponent(this.id);
   }
 
+  /**
+   * Retrieves the string representation of this actor ID.
+   *
+   * Equivalent to {@link getId}, returns the unencoded identifier.
+   *
+   * @returns The actor's identifier string.
+   */
   toString() {
     return this.id;
   }

--- a/src/actors/runtime/ActorCallType.ts
+++ b/src/actors/runtime/ActorCallType.ts
@@ -12,20 +12,45 @@ limitations under the License.
 */
 
 /**
- * Represents the call-type associated with the method invoked by the actor runtime
+ * Discriminates the type of invocation dispatched to an actor method by the runtime.
+ *
+ * The actor runtime invokes actor methods through different pathways depending on the
+ * call source: explicit client invocations, scheduled timer callbacks, or persisted
+ * reminder callbacks. This enum distinguishes these invocation paths, which is useful
+ * for conditional logic or logging within actor implementations.
  */
 export enum ActorCallType {
   /**
-   * Specifies that the method invoked is an actor interface method for a given
-   * client request.
+   * Method invoked by an explicit client request.
+   *
+   * Dispatched when a remote caller invokes a method on an actor through the
+   * Dapr actor runtime via ActorProxyBuilder or direct actor client invocation.
+   * This is the most common actor method invocation type.
    */
   ACTOR_INTERFACE_METHOD,
+
   /**
-   * Specifies that the method invoked is a timer callback method.
+   * Method invoked by a scheduled timer callback.
+   *
+   * Dispatched when an actor's registered timer fires. The callback method name
+   * is specified during timer registration and the method receives state data
+   * optionally provided at timer registration time.
+   *
+   * Timers are NOT persisted across actor deactivation. They are ephemeral
+   * scheduling constructs tied to the current actor activation.
    */
   TIMER_METHOD,
+
   /**
-   * Specifies that the method is when a reminder fires.
+   * Method invoked by a persistent reminder callback.
+   *
+   * Dispatched when an actor's registered reminder fires. The default callback
+   * method is `receiveReminder()` on the actor implementation. Reminder state data
+   * is passed to this callback.
+   *
+   * Reminders persist across actor deactivation and failover, making them suitable
+   * for durable scheduled work. Unlike timers, reminders survive actor restart,
+   * process crash, and cluster failover events.
    */
   REMINDER_METHOD,
 }

--- a/src/actors/runtime/ActorMethodContext.ts
+++ b/src/actors/runtime/ActorMethodContext.ts
@@ -13,6 +13,17 @@ limitations under the License.
 
 import { ActorCallType } from "./ActorCallType";
 
+/**
+ * Provides contextual metadata about an actor method invocation.
+ *
+ * The actor runtime captures invocation context information (method name and invocation type)
+ * and makes it available to the actor method handler. This allows actors to respond differently
+ * depending on whether they're being invoked as a direct method call, timer callback, or
+ * reminder callback.
+ *
+ * ActorMethodContext instances are created by the runtime and typically not directly instantiated
+ * by application code. Use the static factory methods for testing or advanced scenarios.
+ */
 export default class ActorMethodContext {
   private readonly methodName: string;
   private readonly callType: ActorCallType;
@@ -22,22 +33,56 @@ export default class ActorMethodContext {
     this.callType = callType;
   }
 
+  /**
+   * Retrieves the name of the method being invoked.
+   *
+   * @returns The method name, e.g., "increment", "receiveReminder", or a timer callback name.
+   */
   public getMethodName(): string {
     return this.methodName;
   }
 
+  /**
+   * Retrieves the type of actor method invocation.
+   *
+   * @returns The {@link ActorCallType} discriminating the invocation pathway.
+   */
   public getCallType(): ActorCallType {
     return this.callType;
   }
 
+  /**
+   * Creates a context for a direct actor interface method invocation.
+   *
+   * Use this factory when building a context for a client-initiated method call.
+   *
+   * @param methodName - The name of the actor method being invoked.
+   * @returns A new ActorMethodContext with call type {@link ActorCallType.ACTOR_INTERFACE_METHOD}.
+   */
   static createForActor(methodName: string): ActorMethodContext {
     return new ActorMethodContext(methodName, ActorCallType.ACTOR_INTERFACE_METHOD);
   }
 
+  /**
+   * Creates a context for a timer callback method invocation.
+   *
+   * Use this factory when building a context for a scheduled timer firing.
+   *
+   * @param methodName - The name of the timer callback method.
+   * @returns A new ActorMethodContext with call type {@link ActorCallType.TIMER_METHOD}.
+   */
   static createForTimer(methodName: string): ActorMethodContext {
     return new ActorMethodContext(methodName, ActorCallType.TIMER_METHOD);
   }
 
+  /**
+   * Creates a context for a reminder callback method invocation.
+   *
+   * Use this factory when building a context for a persisted reminder firing.
+   *
+   * @param methodName - The name of the reminder callback method (typically "receiveReminder").
+   * @returns A new ActorMethodContext with call type {@link ActorCallType.REMINDER_METHOD}.
+   */
   static createForReminder(methodName: string): ActorMethodContext {
     return new ActorMethodContext(methodName, ActorCallType.REMINDER_METHOD);
   }

--- a/src/actors/runtime/ActorReminderData.ts
+++ b/src/actors/runtime/ActorReminderData.ts
@@ -14,21 +14,83 @@ limitations under the License.
 import BufferSerializer from "./BufferSerializer";
 
 /**
- * Contains the actor reminder data
+ * Configuration and metadata for a persistent actor reminder.
+ *
+ * Reminders are durable, recurring callbacks that survive actor deactivation and failover.
+ * Unlike timers, reminders persist in the Dapr state store and are replayed across restarts.
+ * The reminder will fire at regular intervals specified by `period` after the initial delay.
+ *
+ * ActorReminderData encapsulates the complete reminder specification and is created during
+ * actor reminder registration. It may be serialized/deserialized for transport through the
+ * Dapr runtime.
+ *
+ * @remarks
+ * Reminders have the following lifecycle:
+ * - Registered via {@link AbstractActor#registerActorReminder}
+ * - Persisted in the Dapr state store
+ * - Fired at (dueTime) initially, then every (period) interval
+ * - Expire and are deleted after (ttl) duration if specified
+ * - Unregistered via {@link AbstractActor#unregisterActorReminder}
+ *
+ * The reminder callback method receives the state data passed during registration.
+ * By default, this calls the actor's `receiveReminder()` method.
+ *
+ * @example
+ * ```typescript
+ * // Register a reminder that fires after 2 seconds, then every 5 seconds,
+ * // expires after 1 minute, with custom state data
+ * const reminder = new ActorReminderData(
+ *   "payment-reminder",
+ *   2000,     // dueTime: 2 seconds
+ *   5000,     // period: 5 seconds
+ *   60000,    // ttl: 60 seconds
+ *   { accountId: "user-123", amount: 99.99 }
+ * );
+ * ```
  */
 export default class ActorReminderData {
+  /**
+   * The user-defined name of this reminder, unique within the actor instance.
+   */
   readonly reminderName: string;
+
+  /**
+   * Application-defined state data passed to the reminder callback.
+   * Can be a JSON-serializable object or string.
+   */
   readonly state: string | object | undefined;
+
+  /**
+   * Initial delay in milliseconds before the first reminder firing.
+   */
   readonly dueTime: number;
+
+  /**
+   * Optional time-to-live in milliseconds. After this duration from registration,
+   * the reminder is automatically deleted and will not fire again.
+   */
   readonly ttl: number | undefined;
+
+  /**
+   * Recurrence interval in milliseconds between successive reminder firings
+   * after the initial due time.
+   */
   readonly period: number;
 
   /**
-   * @param reminderName the name of the actor reminder
-   * @param state the state data passed to receiveReminder callback
-   * @param dueTime the amount of time to delay before invoking the reminder for the first time
-   * @param ttl time to duration after which the reminder will be expired and deleted
-   * @param period the time interval between reminder invocations after the first invocation
+   * Constructs an ActorReminderData instance.
+   *
+   * @param reminderName - The name of the reminder, unique within this actor.
+   * @param dueTime - Initial delay in milliseconds before first firing.
+   * @param period - Interval in milliseconds between subsequent firings.
+   * @param ttl - Optional time-to-live in milliseconds. If specified, the reminder
+   *              is automatically deleted after this duration.
+   * @param state - Optional state data to be passed to the reminder callback.
+   *
+   * @example
+   * ```typescript
+   * new ActorReminderData("check-balance", 5000, 10000, 300000, { threshold: 100 });
+   * ```
    */
   constructor(reminderName: string, dueTime: number, period: number, ttl?: number, state?: string | object) {
     this.reminderName = reminderName;
@@ -38,28 +100,59 @@ export default class ActorReminderData {
     this.state = state;
   }
 
+  /**
+   * Retrieves the reminder name.
+   *
+   * @returns The unique reminder identifier within this actor.
+   */
   getReminderName(): string {
     return this.reminderName;
   }
 
+  /**
+   * Retrieves the reminder state data.
+   *
+   * @returns The state passed during registration, or undefined.
+   */
   getState(): string | object | undefined {
     return this.state;
   }
 
+  /**
+   * Retrieves the initial delay before first firing.
+   *
+   * @returns The due time in milliseconds.
+   */
   getDueTime(): number {
     return this.dueTime;
   }
 
+  /**
+   * Retrieves the time-to-live duration.
+   *
+   * @returns The TTL in milliseconds, or undefined if no expiration.
+   */
   getTtl(): number | undefined {
     return this.ttl;
   }
 
+  /**
+   * Retrieves the recurrence interval.
+   *
+   * @returns The period in milliseconds between successive firings.
+   */
   getPeriod(): number {
     return this.period;
   }
 
   /**
-   * Return this class as an object
+   * Converts this reminder to a serializable object representation.
+   *
+   * Used internally for marshaling reminder data to the Dapr runtime.
+   *
+   * @returns An object with fields: reminderName, dueTime, ttl, period, data.
+   *
+   * @internal
    */
   toObject(): object {
     return {
@@ -71,6 +164,17 @@ export default class ActorReminderData {
     };
   }
 
+  /**
+   * Reconstructs an ActorReminderData from a serialized object representation.
+   *
+   * Deserializes the state data using BufferSerializer.
+   *
+   * @param reminderName - The reminder name.
+   * @param obj - The serialized reminder object (typically from Dapr runtime).
+   * @returns A new ActorReminderData instance.
+   *
+   * @internal
+   */
   static fromObject(reminderName: string, obj: any): ActorReminderData {
     const serializer = new BufferSerializer();
 

--- a/src/actors/runtime/ActorStateChange.ts
+++ b/src/actors/runtime/ActorStateChange.ts
@@ -13,25 +13,61 @@ limitations under the License.
 
 import StateChangeKind from "./StateChangeKind";
 
+/**
+ * Represents a single state mutation ready for persistence.
+ *
+ * ActorStateChange encapsulates a state modification that is ready to be sent to the
+ * state provider for persistence. It combines the state key, the new value, and the
+ * type of modification (add, update, or remove).
+ *
+ * These objects are created during the transactional batch process by ActorStateManager
+ * and are sent to StateProvider for atomic persistence through the Dapr state management API.
+ *
+ * @typeParam T - The type of the state value.
+ *
+ * @internal Used by ActorStateManager and StateProvider for transactional persistence.
+ */
 export default class ActorStateChange<T> {
   private readonly stateName: string;
   private readonly value: T;
   private readonly changeKind: StateChangeKind;
 
+  /**
+   * Constructs an ActorStateChange.
+   *
+   * @param stateName - The key identifying this state item.
+   * @param value - The new value to persist (or null for removes).
+   * @param changeKind - The type of modification ({@link StateChangeKind}).
+   */
   constructor(stateName: string, value: T, changeKind: StateChangeKind) {
     this.stateName = stateName;
     this.value = value;
     this.changeKind = changeKind;
   }
 
+  /**
+   * Retrieves the state key.
+   *
+   * @returns The key identifying this state item.
+   */
   getStateName(): string {
     return this.stateName;
   }
 
+  /**
+   * Retrieves the state value to be persisted.
+   *
+   * @returns The new state value (or null for removes).
+   */
   getValue(): T {
     return this.value;
   }
 
+  /**
+   * Retrieves the kind of modification.
+   *
+   * @returns The {@link StateChangeKind} (ADD, UPDATE, or REMOVE).
+   */
   getChangeKind(): StateChangeKind {
     return this.changeKind;
   }

--- a/src/actors/runtime/ActorTimerData.ts
+++ b/src/actors/runtime/ActorTimerData.ts
@@ -14,17 +14,75 @@ limitations under the License.
 import BufferSerializer from "./BufferSerializer";
 
 /**
- * Contains the actor reminder data
+ * Configuration and metadata for an ephemeral actor timer.
+ *
+ * Timers are non-durable, recurring callbacks that exist only for the lifetime of the
+ * current actor activation. Unlike reminders, timers are not persisted and are lost on
+ * actor deactivation or failover. Timers are useful for ephemeral state management,
+ * cleanup tasks, and timeout-based logic.
+ *
+ * ActorTimerData encapsulates the complete timer specification. It is created during
+ * actor timer registration and managed by the actor runtime. The current implementation
+ * supports basic timer scheduling with dueTime and period. Future enhancements may add
+ * time-to-live (TTL) and jitter support.
+ *
+ * @remarks
+ * Timers have the following lifecycle:
+ * - Registered via {@link AbstractActor#registerActorTimer}
+ * - Stored in memory, not persisted to the Dapr state store
+ * - Fired at (dueTime) initially, then every (period) interval (if period > 0)
+ * - Automatically cancelled if the actor is deactivated
+ * - Unregistered via {@link AbstractActor#unregisterActorTimer}
+ *
+ * The timer callback method receives the state data passed during registration and
+ * the callback method name to invoke. The callback is routed through the actor's
+ * method invocation system as a direct method call.
+ *
+ * @example
+ * ```typescript
+ * // Register a timer that fires after 1 second, then every 3 seconds,
+ * // calling the "onTimer" method with custom state
+ * const timer = new ActorTimerData(
+ *   "cleanup-timer",
+ *   "onTimer",
+ *   1000,    // dueTime: 1 second
+ *   3000,    // period: 3 seconds
+ *   { sessionId: "sess-456" }
+ * );
+ * ```
  */
 export default class ActorTimerData {
+  /**
+   * The user-defined name of this timer, unique within the actor instance.
+   */
   readonly timerName: string;
+
+  /**
+   * Application-defined state data passed to the timer callback method.
+   * Can be a JSON-serializable object or string.
+   */
   readonly state: string | object | undefined;
+
+  /**
+   * The name of the callback method to invoke when the timer fires.
+   * This method must exist on the actor implementation.
+   */
   readonly callback: string;
 
   /**
-   * @param reminderName the name of the actor reminder
-   * @param state the state data passed to receiveReminder callback
-   * @param callback the callback method to call
+   * Constructs an ActorTimerData instance.
+   *
+   * Note: The current implementation only supports basic timing with dueTime and period.
+   * Time-to-live (TTL) and period are managed by the ActorManager, not this class.
+   *
+   * @param timerName - The name of the timer, unique within this actor.
+   * @param callback - The name of the callback method to invoke.
+   * @param state - Optional state data to be passed to the callback.
+   *
+   * @example
+   * ```typescript
+   * new ActorTimerData("session-timeout", "onSessionTimeout", { sessionId: "x" });
+   * ```
    */
   constructor(timerName: string, callback: string, state?: string | object | undefined) {
     this.timerName = timerName;
@@ -32,20 +90,42 @@ export default class ActorTimerData {
     this.state = state;
   }
 
+  /**
+   * Retrieves the timer name.
+   *
+   * @returns The unique timer identifier within this actor.
+   */
   getTimerName(): string {
     return this.timerName;
   }
 
+  /**
+   * Retrieves the timer state data.
+   *
+   * @returns The state passed during registration, or undefined if no state.
+   */
   getState(): string | object | undefined {
     return this.state;
   }
 
+  /**
+   * Retrieves the callback method name.
+   *
+   * @returns The method name to be invoked when the timer fires.
+   */
   getCallback(): string {
     return this.callback;
   }
 
   /**
-   * Return this class as an object
+   * Converts this timer to a serializable object representation.
+   *
+   * Used internally for marshaling timer data during method invocation and
+   * for passing to the timer callback handler.
+   *
+   * @returns An object with fields: callback, data.
+   *
+   * @internal
    */
   toObject(): object {
     return {
@@ -54,7 +134,19 @@ export default class ActorTimerData {
     };
   }
 
-  static fromObject(reminderName: string, obj: any): ActorTimerData {
+  /**
+   * Reconstructs an ActorTimerData from a serialized object representation.
+   *
+   * Deserializes the state data using BufferSerializer to convert from Buffer
+   * or JSON format to JavaScript values.
+   *
+   * @param timerName - The timer name.
+   * @param obj - The serialized timer object (typically from actor runtime).
+   * @returns A new ActorTimerData instance.
+   *
+   * @internal
+   */
+  static fromObject(timerName: string, obj: any): ActorTimerData {
     const serializer = new BufferSerializer();
 
     const callback = obj?.callback;
@@ -62,6 +154,6 @@ export default class ActorTimerData {
 
     const deserializedData = serializer.deserialize(data);
 
-    return new ActorTimerData(reminderName, callback, deserializedData);
+    return new ActorTimerData(timerName, callback, deserializedData);
   }
 }

--- a/src/actors/runtime/BufferSerializer.ts
+++ b/src/actors/runtime/BufferSerializer.ts
@@ -11,7 +11,58 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/**
+ * Converts between binary buffers and JavaScript values using JSON encoding.
+ *
+ * BufferSerializer handles the bidirectional conversion between Node.js Buffer objects
+ * (used for actor method arguments and reminder/timer state) and JavaScript values. It uses
+ * JSON as the serialization format:
+ *
+ * - **Deserialization**: Converts a Buffer to a string, then attempts JSON.parse(). If parsing
+ *   fails, the string value is returned as-is. This allows graceful handling of both JSON-encoded
+ *   objects and plain text values.
+ *
+ * - **Serialization**: Converts objects to JSON strings, strings are converted directly, and
+ *   other types are stringified. The result is encoded to a Buffer.
+ *
+ * @remarks
+ * This serializer is used internally by the actor runtime for:
+ * - Deserializing actor method arguments from HTTP/gRPC payloads
+ * - Deserializing reminder and timer state data
+ * - Serializing actor method return values
+ * - Marshaling actor invocation data through the Dapr sidecar
+ *
+ * The implementation is lenient—invalid JSON falls back to string representation rather than
+ * throwing errors, which accommodates both structured (JSON) and unstructured (plain text) payloads.
+ *
+ * @internal Intended for use by the actor runtime; not typically used directly by application code.
+ */
 export default class BufferSerializer {
+  /**
+   * Converts a Buffer to a JavaScript value.
+   *
+   * Attempts to parse the buffer contents as JSON. If JSON parsing fails, returns the
+   * string representation of the buffer. Empty or null buffers result in an empty string.
+   *
+   * @param data - The Buffer to deserialize (may be undefined or null).
+   * @returns The deserialized value: a parsed JSON object, a string, or an empty string.
+   *
+   * @example
+   * ```typescript
+   * const serializer = new BufferSerializer();
+   *
+   * // JSON payload
+   * const jsonBuf = Buffer.from('{"count": 42}');
+   * serializer.deserialize(jsonBuf); // { count: 42 }
+   *
+   * // Plain text payload
+   * const textBuf = Buffer.from('hello world');
+   * serializer.deserialize(textBuf); // "hello world"
+   *
+   * // Empty buffer
+   * serializer.deserialize(Buffer.from('')); // ""
+   * ```
+   */
   deserialize(data: Buffer): any {
     let deserializedBody: any = data?.toString() || "";
 
@@ -26,6 +77,32 @@ export default class BufferSerializer {
     return deserializedBody;
   }
 
+  /**
+   * Converts a JavaScript value to a Buffer.
+   *
+   * Objects are JSON-stringified, strings are used directly, and other types are converted
+   * to strings. The result is encoded to a Buffer using UTF-8.
+   *
+   * @param data - The value to serialize (object, string, or other type).
+   * @returns A UTF-8 encoded Buffer containing the serialized data.
+   *
+   * @example
+   * ```typescript
+   * const serializer = new BufferSerializer();
+   *
+   * // Serialize an object
+   * serializer.serialize({ count: 42 });
+   * // Buffer.from('{"count":42}')
+   *
+   * // Serialize a string
+   * serializer.serialize("hello world");
+   * // Buffer.from('hello world')
+   *
+   * // Serialize a number (converted to string)
+   * serializer.serialize(42);
+   * // Buffer.from('42')
+   * ```
+   */
   serialize(data: any): Buffer {
     let dataAsString: string;
 

--- a/src/actors/runtime/StateChangeKind.ts
+++ b/src/actors/runtime/StateChangeKind.ts
@@ -12,17 +12,48 @@ limitations under the License.
 */
 
 /**
- * A enumeration that represents the kind of state change for an actor state
- * when saves change is called to a set of actor states.
+ * Discriminates the type of modification made to an actor state item.
+ *
+ * The actor state manager tracks modifications to actor state through transactional
+ * state batches. Each change is tagged with its kind to determine how the state
+ * persistence layer should handle it when `saveState()` is called.
+ *
+ * State changes are staged locally and only persisted when {@link ActorStateManager#saveState}
+ * is explicitly called (typically at the end of each actor method invocation).
  */
 enum StateChangeKind {
-  // No change in state
+  /**
+   * No pending modification for this state item.
+   *
+   * The state item exists in persistent storage but has not been modified during
+   * this invocation. No action is required on persistence.
+   */
   NONE = 0,
-  // The state needs to be added
+
+  /**
+   * State item is newly added and must be persisted.
+   *
+   * This state key did not exist before this invocation and has been created through
+   * `addState()` or `getOrAddState()`. Will be persisted as an "upsert" (insert or update)
+   * operation to the state provider.
+   */
   ADD = 1,
-  // The state needs to be updated
+
+  /**
+   * State item has been modified and must be updated in persistent storage.
+   *
+   * The state key existed prior to this invocation (or was marked for removal) and has been
+   * modified through `setState()` or `addOrUpdateState()`. Will be persisted as an "upsert"
+   * operation to the state provider.
+   */
   UPDATE = 2,
-  // The state needs to be removed
+
+  /**
+   * State item must be removed from persistent storage.
+   *
+   * This state key is marked for deletion through `removeState()` or `tryRemoveState()`.
+   * Will be persisted as a "delete" operation to the state provider.
+   */
   REMOVE = 3,
 }
 

--- a/src/actors/runtime/StateMetadata.ts
+++ b/src/actors/runtime/StateMetadata.ts
@@ -13,27 +13,68 @@ limitations under the License.
 
 import StateChangeKind from "./StateChangeKind";
 
+/**
+ * Tracks the current value and modification state of a cached actor state item.
+ *
+ * The actor state manager uses StateMetadata to maintain a local cache of state
+ * during an actor method invocation. Each state item tracks both its current value
+ * and the kind of modification that has been applied to it since it was loaded or
+ * created.
+ *
+ * This metadata is transient—it is cleared at the beginning of each actor method
+ * invocation and persisted at the end through the state provider.
+ *
+ * @typeParam T - The type of the state value.
+ *
+ * @internal Intended for use by ActorStateManager; not typically used directly by application code.
+ */
 export default class StateMetadata<T> {
   private value: T;
   private changeKind: StateChangeKind;
 
+  /**
+   * Constructs a StateMetadata instance.
+   *
+   * @param value - The current state value.
+   * @param changeKind - The type of modification applied to this state ({@link StateChangeKind}).
+   */
   constructor(value: T, changeKind: StateChangeKind) {
     this.value = value;
     this.changeKind = changeKind;
   }
 
+  /**
+   * Retrieves the current state value.
+   *
+   * @returns The state value.
+   */
   getValue(): T {
     return this.value;
   }
 
+  /**
+   * Retrieves the modification kind for this state item.
+   *
+   * @returns The {@link StateChangeKind} indicating ADD, UPDATE, REMOVE, or NONE.
+   */
   getChangeKind(): StateChangeKind {
     return this.changeKind;
   }
 
+  /**
+   * Updates the state value.
+   *
+   * @param value - The new state value.
+   */
   setValue(value: T): void {
     this.value = value;
   }
 
+  /**
+   * Updates the modification kind for this state item.
+   *
+   * @param changeKind - The new {@link StateChangeKind}.
+   */
   setChangeKind(changeKind: StateChangeKind): void {
     this.changeKind = changeKind;
   }


### PR DESCRIPTION
# Description

The main goal is to make the actor internals easier to understand for both SDK users and contributors by documenting lifecycle behavior, actor state semantics, reminders/timers, invocation context, and serialization behavior.

Closes #795 

## Covered files

### Actor identity

* `ActorId.ts`

### Actor runtime models

* `ActorCallType.ts`
* `ActorMethodContext.ts`
* `ActorReminderData.ts`
* `ActorTimerData.ts`

### Actor state models

* `ActorStateChange.ts`
* `StateChangeKind.ts`
* `StateMetadata.ts`

### Serialization

* `BufferSerializer.ts`

## What was added

* Class-level and method-level JSDoc
* Enum value documentation
* Lifecycle and persistence explanations
* State mutation and batching semantics
* Usage examples where helpful

This is a documentation-only PR:

* No runtime logic changes
* No API changes
* No behavior changes

## Follow-up

This PR covers the actor runtime model/state layer first to keep the review focused and manageable.

Additional actor runtime files such as:

* `AbstractActor.ts`
* `ActorRuntime.ts`
* `ActorManager.ts`
* `ActorStateManager.ts`
* `StateManager.ts`
* `StateProvider.ts`
* `ActorProxyBuilder.ts`

can be documented in follow-up PRs.
