### PR TITLE
Update buf configuration to emit CommonJS modules instead of ESM

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,12 +8,14 @@ plugins:
     opt:
       - target=js+dts
       - import_extension=.js
+      - js_import_style=legacy_commonjs
   - remote: buf.build/connectrpc/es
     out: ./src/proto
     include_imports: true
     opt:
       - target=js+dts
       - import_extension=.js
+      - js_import_style=legacy_commonjs
 inputs:
   - directory: ./
     paths:


### PR DESCRIPTION
# Description

Modified buf configuration to emit CommonJS modules so Dapr build produces a uniform module style.

By default Buf emits ESM and because it outputs as .js files, TSC doesn't modify them, so consumers of the produced Dapr distributable would likely have seen import issues because of the module blend.

Validated build output locally following this change and confirmed that buf outputs are emitting CommonJS as expected.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #825

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [X] Code compiles correctly
- [X] Created/updated tests
- [ ] Extended the documentation
