### PR TITLE
docs(configuration): add Configuration section to reference.md (#351)

### DIFF
--- a/documentation/reference.md
+++ b/documentation/reference.md
@@ -32,3 +32,33 @@ await client.invoker.listen("method", invokerListen.bind(this), options);
 ## Actors
 
 ## Secrets
+
+## Configuration
+
+The configuration methods are created as a wrapper on the [Dapr Configuration API](https://docs.dapr.io/reference/api/configuration_api/). The Configuration API is currently only implemented for the gRPC client; calling any `client.configuration` method on the HTTP client throws an `HTTPNotSupportedError`.
+
+### Getting configuration items
+
+```typescript
+const config = await client.configuration.get("config-store", ["myconfigkey1", "myconfigkey2"]);
+console.log(config.items["myconfigkey1"]); // { key: "myconfigkey1", value: "...", version: "...", metadata: {} }
+```
+
+### Subscribing to configuration changes
+
+Subscribe to be notified whenever configuration items change in the store. The callback is invoked with the items that changed; call `stop()` on the returned stream to unsubscribe.
+
+```typescript
+const stream = await client.configuration.subscribeWithKeys(
+  "config-store",
+  ["myconfigkey1", "myconfigkey2"],
+  async (data) => {
+    console.log("Configuration updated: ", data);
+  },
+);
+
+// Later, stop listening for changes
+stream.stop();
+```
+
+Use `client.configuration.subscribe(storeName, cb)` to subscribe to all keys in the store instead of a specific set, or `client.configuration.subscribeWithMetadata(storeName, keys, metadata, cb)` to pass store-specific metadata along with the subscription.


### PR DESCRIPTION
<!-- PR title: docs(configuration): add Configuration section to reference.md (#351) -->

**You set the work.** #351: the Configuration building block (`subscribeConfiguration` et al.) shipped long ago, but `documentation/reference.md` has no Configuration section.

**It's done.** A `## Configuration` section documenting `get`, `subscribe` (plain, with-keys, with-metadata), and unsubscription via `stream.stop()` — mirroring the structure of the one section that has real content (Service Invocation). Every snippet is based on the working `examples/configuration/` code and was compile-checked against the real exports (`tsc --noEmit`, strict, zero errors). One caveat surfaced and documented: the Configuration API is **gRPC-only** — the HTTP client throws `HTTPNotSupportedError` for all four methods, which is broader than the issue implied.

**Here's the evidence.**

- Fresh clone at `f7800662`, patch applied, `npm install && npm run build`, then the network was disconnected.
- Unit suite in a clean `node:22-bookworm` container: **all 10 suite groups pass**.
- Prettier introduces zero new violations (same 56 pre-existing non-conforming files with or without this change); eslint untouched by a docs-only diff.

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `f78006628ea259d16173a78184b929292f1d612f` |
| Container | `node:22-bookworm@sha256:5647be70…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f01551220ca3a25a9e37e4e03674638ab002783cb3dc05217847b874dec6b79f57aefd11a) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f0155122089e224c9d5002a6d962facaced6112a9ab0fe796ad0e2a45906043acbfd60624) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0x39461a6369e2b994ab3e6525fd13e2cee3fcf4f17abac8983fa5ccf2f03ef33a) → [work delivered](https://sepolia.basescan.org/tx/0xd8908b9ee05d965f3f1f42bf7783c2137b98f66de685deffcfb70b959a0d9813) → [checks passed](https://sepolia.basescan.org/tx/0xe0ff8bdbc68e3c88a4fc83c335d6906ec6be3586e8b03a6de507bda1aa377471) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the docs are *right* in every nuance. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review, signed off per the DCO. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Closes #351.

One file changed: `documentation/reference.md`, +30 lines. Structure mirrors Service Invocation (one-line description + link to the matching Dapr API doc, then `###` subsections with short TypeScript snippets); the other section headers (State Management, Pub/Sub, Bindings, Actors, Secrets) are empty stubs since 2021 and were left untouched.

### Notes for the reviewer

- The section is intentionally skeletal to match the file's actual current style — if you'd like fuller coverage (error handling, a link to `examples/configuration/`, the Redis metadata caveat from the e2e comments), happy to extend.
- `documentation/examples.md` also lacks a Configuration entry — a second, separate gap left alone here; can follow up.
