### PR TITLE
docs: clarify handling of missing state

### DIFF
--- a/examples/grpc/hello-world/README.md
+++ b/examples/grpc/hello-world/README.md
@@ -16,3 +16,28 @@ docker run -d --rm --hostname my-rabbitmq --name my-rabbitmq \
 # Run the example
 npm run start:dapr
 ```
+
+## Handling missing state
+
+When retrieving state with `client.state.get()`, the requested key may not exist.
+
+The example demonstrates this by deleting `key-2` and then attempting to retrieve it:
+
+```typescript
+await client.state.delete("state-redis", "key-2");
+
+const resStateDelete = await client.state.get("state-redis", "key-2");
+
+if (resStateDelete === "") {
+  console.log("[Dapr-JS][Example][State] State 'key-2' does not exist");
+} else {
+  console.log(
+    "[Dapr-JS][Example][State] State 'key-2' retrieved:",
+    resStateDelete,
+  );
+}
+```
+
+When the requested state does not exist, the HTTP state API returns `204 No Content`. The JavaScript SDK treats this as a successful response and returns an empty string.
+
+Other HTTP errors, such as `400` or `500`, are returned as errors and should be handled separately.

--- a/examples/grpc/hello-world/src/index.ts
+++ b/examples/grpc/hello-world/src/index.ts
@@ -135,8 +135,17 @@ async function start() {
   console.log(`[Dapr-JS][Example][State] Fetched State Bulk: ${JSON.stringify(resStateBulk)}`);
 
   await client.state.delete("state-redis", "key-2");
+
   const resStateDelete = await client.state.get("state-redis", "key-2");
-  console.log(`[Dapr-JS][Example][State] Deleted State "key-2" ${JSON.stringify(resStateDelete)}`);
+
+  if (resStateDelete === "") {
+    console.log("[Dapr-JS][Example][State] State 'key-2' does not exist");
+  } else {
+    console.log(
+      "[Dapr-JS][Example][State] State 'key-2' retrieved:",
+      resStateDelete,
+    );
+  }
 
   // After the above we have key-1 and key-3 left. Let's change key-1 to my-new-data-1 and delete key-3
   await client.state.transaction("state-redis", [


### PR DESCRIPTION
# Description

Clarifies how the gRPC state example handles a missing state value.

When `key-2` is deleted and then retrieved, the example now explicitly checks for an empty result and reports that the state does not exist. The README also documents how missing state is handled and how other HTTP errors should be treated.

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #477

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [ ] Created/updated tests
- [x] Extended the documentation