### PR TITLE
feat: add @scarf/scarf install analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ npm install --save @dapr/dapr-dev
 
 Visit [https://docs.dapr.io/developing-applications/sdks/js/](https://docs.dapr.io/developing-applications/sdks/js/) to view the full documentation.
 
+## Installation Analytics
+
+`@dapr/dapr` includes [`@scarf/scarf`](https://github.com/scarf-sh/scarf-js), which reports basic, anonymized install information (operating system, package name and version) to help Dapr maintainers understand SDK adoption. It only runs at install time — there is no runtime footprint and no data collection after installation. Scarf uses the request IP for company-level aggregation and does not store it.
+
+To opt out, set either environment variable before installing:
+
+```bash
+export SCARF_ANALYTICS=false
+# or
+export DO_NOT_TRACK=1
+```
+
+or add the following to your project's `package.json`:
+
+```json
+"scarfSettings": { "enabled": false }
+```
+
 ## Community
 
 There are multiple ways to get involved with the SDK community, please see [wiki/Community-engagement](https://github.com/dapr/js-sdk/wiki/Community-engagement) for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@dapr/durabletask-js": "^1.0.0",
         "@grpc/grpc-js": "^1.12.5",
         "@js-temporal/polyfill": "^0.3.0",
+        "@scarf/scarf": "^1.4.0",
         "@types/google-protobuf": "^3.15.5",
         "@types/node-fetch": "^2.6.2",
         "body-parser": "^1.19.0",
@@ -1643,6 +1644,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -10033,6 +10041,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg=="
+    },
+    "@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
     },
     "@sec-ant/readable-stream": {
       "version": "0.4.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,10 @@
   "keywords": [],
   "author": "Dapr Authors",
   "license": "apache-2.0",
+  "scarfSettings": {
+    "defaultOptIn": true,
+    "allowTopLevel": false
+  },
   "dependencies": {
     "@bufbuild/protobuf": "^2.9.0",
     "@connectrpc/connect": "^2.1.0",
@@ -62,6 +66,7 @@
     "@dapr/durabletask-js": "^1.0.0",
     "@grpc/grpc-js": "^1.12.5",
     "@js-temporal/polyfill": "^0.3.0",
+    "@scarf/scarf": "^1.4.0",
     "@types/google-protobuf": "^3.15.5",
     "@types/node-fetch": "^2.6.2",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
# Description

**Proposal:** add [`@scarf/scarf`](https://github.com/scarf-sh/scarf-js) install-time analytics to `@dapr/dapr`.

**Why:** npm exposes only aggregate download counts, so the project has no visibility into SDK adoption. Dapr already uses Scarf for analytics elsewhere — the docs.dapr.io footer pixel, Maven Central download stats for the Java SDK, and Scarf.sh is listed as a community-managed tool in [COMMUNITY-MANAGER.md](https://github.com/dapr/community/blob/master/COMMUNITY-MANAGER.md). This extends the same visibility to the JS SDK. Related: dapr/cli#1689 routes CLI install-script downloads through a Scarf gateway.

**What it does:**

- Runs only as a postinstall hook when `@dapr/dapr` is installed as a dependency of another project — no runtime footprint, nothing imported at runtime.
- Reports operating system and package name/version. Scarf uses the request IP for company-level aggregation and does not store it ([scarf-js docs](https://github.com/scarf-sh/scarf-js#what-information-does-scarf-js-provide-me-as-a-maintainer)).
- `allowTopLevel: false` — contributors running `npm install` inside a js-sdk checkout are **not** reported.
- Opt-outs honored: `SCARF_ANALYTICS=false`, the `DO_NOT_TRACK=1` standard, `"scarfSettings": { "enabled": false }` in the consumer's package.json, or installing with `--ignore-scripts`.
- The README gains an "Installation Analytics" disclosure section with opt-out instructions.
